### PR TITLE
Only loop over first ten objects in bottom nav links

### DIFF
--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -84,26 +84,26 @@
         <div class="col-xs-6 col-sm-{{ width }}">
               <h3>Source Files</h3>
               <ul>
-                {% for src in project.allfiles|sort(attribute='name') %}
+                {%- for src in (project.allfiles|sort(attribute='name'))[:10] -%}
                   {% if loop.index0 < 10 %}
                     <li>{{ src }}</li>
                   {% elif loop.index0 == 10 %}
                     <li><a href="{{ project_url }}/lists/files.html"><em>All source files&hellip;</em></a></li>
-                  {% endif %}
-                {% endfor %}
+                  {%- endif -%}
+                {%- endfor -%}
               </ul>
           </div>
           {% if project.modules|length > 0 %}
 		  <div class="col-xs-6 col-sm-{{ width }}">
               <h3>Modules</h3>
               <ul>
-                {% for mod in project.modules|sort(attribute='name') %}
+                {%- for mod in (project.modules|sort(attribute='name'))[:10] -%}
                   {% if loop.index0 < 10 %}
                     <li>{{ mod }}</li>
                   {% elif loop.index0 == 10 %}
                     <li><a href="{{ project_url }}/lists/modules.html"><em>All modules&hellip;</em></a></li>
-                  {% endif %}
-                {% endfor %}
+                  {%- endif -%}
+                {%- endfor -%}
               </ul>
           </div>
           {% endif %}
@@ -111,13 +111,13 @@
 		  <div class="col-xs-6 col-sm-{{ width }}">
               <h3>Procedures</h3>
               <ul>
-                {% for proc in project.procedures|sort(attribute='name') %}
+                {%- for proc in (project.procedures|sort(attribute='name'))[:10] -%}
                   {% if loop.index0 < 10 %}
                     <li>{{ proc }}</li>
                   {% elif loop.index0 == 10 %}
                     <li><a href="{{ project_url }}/lists/procedures.html"><em>All procedures&hellip;</em></a></li>
-                  {% endif %}
-                {% endfor %}
+                  {%- endif -%}
+                {%- endfor -%}
               </ul>
           </div>
           {% endif %}
@@ -125,13 +125,13 @@
 		  <div class="col-xs-6 col-sm-{{ width }}">
               <h3>Derived Types</h3>
               <ul>
-                {% for dtype in project.types|sort(attribute='name') %}
+                {%- for dtype in (project.types|sort(attribute='name'))[:10] -%}
                   {% if loop.index0 < 10 %}
                     <li>{{ dtype }}</li>
                   {% elif loop.index0 == 10 %}
                     <li><a href="{{ project_url }}/lists/types.html"><em>All derived types&hellip;</em></a></li>
-                  {% endif %}
-                {% endfor %}
+                  {%- endif -%}
+                {%- endfor -%}
               </ul>
           </div>
           {% endif %}


### PR DESCRIPTION
Avoids extraneous blank lines in `index.html` for projects with lots of procedures/modules, etc.

A very minor problem, but my text editor was choking on 6000+ blank lines for some reason.