### PR TITLE
Prevent IndexError on single ampersands

### DIFF
--- a/ford/reader.py
+++ b/ford/reader.py
@@ -255,6 +255,10 @@ class FortranReader(object):
                 if line[0] == '&':
                     if continued:
                         line = line[1:]
+                        if len(line.strip()) == 0:
+                            # If the line contained only an "&" and `continued==True` then
+                            # we keep going.
+                            continue
                     elif len(line.strip()) == 1:
                         continue
                     else:


### PR DESCRIPTION
The previous fix for this does not account for `continued=True`. The same behaviour should apply in this case.

The failure I saw was the next block checks if `line[-1] == '&'` but this line can be empty and hence indexing it at `-1` causes an exception.