### PR TITLE
Fix anchors being hid by navbar for all elements

### DIFF
--- a/ford/css/local.css
+++ b/ford/css/local.css
@@ -12,11 +12,8 @@ body {
       white-space:nowrap;
     }
 
-    :target:before {
-      content:"";
-      display:block;
-      height:60px;
-      margin:-60px 0 0;
+    html {
+      scroll-padding-top: 70px;
     }
 
     ol.hierarchy {


### PR DESCRIPTION
This is a cleaner fix than the previous implementation that works on all elements. The existing fix breaks when the anchor is on a table row and ends up adding an unwanted horizontal offset.

See here for demo: https://jsfiddle.net/18evn5pk/
Uncomment the `:target:before` CSS to see the difference

Solution from: https://stackoverflow.com/a/56467997/2043465

`scroll-padding-top` has pretty widespread support: https://caniuse.com/#search=scroll-padding-top