### PR TITLE
Allow submodule procedures to have CONTAINS statements

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2220,7 +2220,8 @@ class GenericSource(FortranBase):
 
 
 _can_have_contains = [FortranModule,FortranProgram,FortranFunction,
-                      FortranSubroutine,FortranType,FortranSubmodule]
+                      FortranSubroutine,FortranType,FortranSubmodule,
+                      FortranSubmoduleProcedure]
 
 def line_to_variables(source, line, inherit_permission, parent):
     """


### PR DESCRIPTION
This PR fixes the inability for submodule procedures to have `CONTAINS` statements, as reported in #245. By instance:

```fortran
module foo_module
  interface
    module subroutine foo()
    end subroutine
  end interface
end module

submodule(foo_module) foo_submodule
contains
  module procedure foo
  contains
    subroutine bar()
    end subroutine
  end procedure
end submodule
```