### PR TITLE
Add support for python -m ford

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -96,7 +96,7 @@ def initialize():
         ncpus = '0'
 
     # Setup the command-line options and parse them.
-    parser = argparse.ArgumentParser(description="Document a program or library written in modern Fortran. Any command-line options over-ride those specified in the project file.")
+    parser = argparse.ArgumentParser("ford", description="Document a program or library written in modern Fortran. Any command-line options over-ride those specified in the project file.")
     parser.add_argument("project_file",help="file containing the description and settings for the project",
                         type=argparse.FileType('r'))
     parser.add_argument("-d","--src_dir",action="append",help='directories containing all source files for the project')

--- a/ford/__main__.py
+++ b/ford/__main__.py
@@ -1,0 +1,3 @@
+from ford import run
+
+run()


### PR DESCRIPTION
```
👍 python -m ford
usage: __main__.py [-h] [-d SRC_DIR] [-p PAGE_DIR] [-o OUTPUT_DIR] [-s CSS] [-r REVISION] [--exclude EXCLUDE]
                   [--exclude_dir EXCLUDE_DIR] [-e EXTENSIONS] [-m MACRO] [-w] [--no-search] [-q] [-V] [--debug]
                   [-I INCLUDE]
                   project_file
__main__.py: error: the following arguments are required: project_file
🙅 ./ford.py 
usage: ford.py [-h] [-d SRC_DIR] [-p PAGE_DIR] [-o OUTPUT_DIR] [-s CSS] [-r REVISION] [--exclude EXCLUDE]
               [--exclude_dir EXCLUDE_DIR] [-e EXTENSIONS] [-m MACRO] [-w] [--no-search] [-q] [-V] [--debug]
               [-I INCLUDE]
               project_file
ford.py: error: the following arguments are required: project_file
🙅
```
We might need to specify the executable name in https://github.com/Fortran-FOSS-Programmers/ford/blob/master/ford/__init__.py#L100