### PR TITLE
Fix and update URLs for intrinsic modules.

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -93,7 +93,7 @@ LICENSES = {
     "pdl": '<a rel="license" href="http://www.openoffice.org/licenses/PDL.html">Public Documentation License</a>',
     "bsd": '<a rel="license" href="http://www.freebsd.org/copyright/freebsd-doc-license.html">FreeBSD Documentation License</a>',
     "isc": '<a rel="license" href="https://opensource.org/licenses/ISC">ISC (Internet Systems Consortium) License</a>',
-    "mit": '<a rel="license" href="https://opensource.org/licenses/">MIT</a>',
+    "mit": '<a rel="license" href="https://opensource.org/licenses/MIT">MIT</a>',
     "": "",
 }
 

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -33,13 +33,13 @@ import ford.sourceform
 
 
 INTRINSIC_MODS = {
-    "iso_fortran_env": '<a href="http://fortranwiki.org/fortran/show/ISO_FORTRAN_ENV">iso_fortran_env</a>',
-    "iso_c_binding": '<a href="http://fortranwiki.org/fortran/show/ISO_C_BINDING">iso_c_binding</a>',
-    "ieee_arithmetic": '<a href="http://fortranwiki.org/fortran/show/IEEE_ARITHMETIC">ieee_arithmetic</a>',
+    "iso_fortran_env": '<a href="http://fortranwiki.org/fortran/show/iso_fortran_env">iso_fortran_env</a>',
+    "iso_c_binding": '<a href="http://fortranwiki.org/fortran/show/iso_c_binding">iso_c_binding</a>',
+    "ieee_arithmetic": '<a href="http://fortranwiki.org/fortran/show/ieee_arithmetic">ieee_arithmetic</a>',
     "ieee_exceptions": '<a href="http://fortranwiki.org/fortran/show/IEEE+arithmetic">ieee_exceptions</a>',
     "ieee_features": '<a href="http://fortranwiki.org/fortran/show/IEEE+arithmetic">ieee_features</a>',
-    "openacc": '<a href="http://www.openacc.org/sites/default/files/OpenACC.2.0a_1.pdf#page=49">openacc</a>',
-    "omp_lib": '<a href="https://gcc.gnu.org/onlinedocs/gcc-4.4.3/libgomp/Runtime-Library-Routines.html">omp_lib</a>',
+    "openacc": '<a href="https://www.openacc.org/sites/default/files/inline-images/Specification/OpenACC.3.0.pdf#page=85">openacc</a>',
+    "omp_lib": '<a href="https://www.openmp.org/spec-html/5.1/openmpch3.html#x156-1890003">omp_lib</a>',
     "mpi": '<a href="http://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node410.htm">mpi</a>',
     "mpi_f08": '<a href="http://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node409.htm">mpi_f08</a>',
 }


### PR DESCRIPTION
Closes #343

The OpenACC still points to a PDF which is a bit of a shame, but I
couldn't see an HTML version on their website.

The Fortran wiki is probably still the best place for the intrinsic
modules. fortran-lang.org looks shinier, but it doesn't seem to have
all the info the wiki does.

Update OpenMP link to the official spec for 5.1

MPI links left for the time being: MPI 4.0 is out, but official spec
is still PDF-only at the moment. We should update this if an HTML
version is released