### PR TITLE
Make sure "Find us on" present if `project_gitlab` set

### DIFF
--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -3,7 +3,7 @@
       <!-- Main component for a primary marketing message or call to action -->
       <div class="jumbotron">
         {{ summary }}
-        	 {% if project_github or project_bitbucket or project_sourceforge or project_website %}
+        	 {% if project_github or project_bitbucket or project_gitlab or project_sourceforge or project_website %}
 	<p> Find us on&hellip;</p>
         <p>
 			 {% if project_github %}


### PR DESCRIPTION
Previously setting `project_gitlab` in the configuration file would not lead to a find us on button appearing.

We may also wish to change line 13 to say "Gitlab" rather than "The web" as well.