### PR TITLE
Fixed module variable INTRINSIC_MODS being changed implicitly. 

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -197,7 +197,7 @@ class Project(object):
 
         print("Correlating information from different parts of your project...")
 
-        non_local_mods = INTRINSIC_MODS
+        non_local_mods = INTRINSIC_MODS.copy()
         for item in self.settings["extra_mods"]:
             try:
                 i = item.index(":")

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -2,6 +2,7 @@ import sys
 import pytest
 from collections import defaultdict
 import ford
+import ford.fortran_project
 
 # Ford default src folder
 DEFAULT_SRC = "src"
@@ -50,3 +51,26 @@ extra_mods:
         ford.run()
 
 
+def test_extra_mods_intrinsic(copy_fortran_file, copy_settings_file, monkeypatch, tmp_path):
+    """This checks that adding extra_mods doesn't change the module variable INTRINSIC_MODS"""
+    data = """\
+module test
+end module test
+"""
+    settings = """\
+extra_mods: dummy: dummy_module
+"""
+    # Initial value of intrinsic mods
+    old_intrinsic_mods = ford.fortran_project.INTRINSIC_MODS.copy()
+
+    # set up project data
+    copy_fortran_file(data)
+    md_file = copy_settings_file(settings)
+
+    # Modify command line args with argv to use
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'argv', ["ford", str(md_file)])
+        ford.run()
+
+    # Check that the module level variable has not been changed
+    assert ford.fortran_project.INTRINSIC_MODS == old_intrinsic_mods


### PR DESCRIPTION
This an additional issue that is probably unexpected behavior that I spotted while doing the previous fix. fortran_project defines a module variable INTRINSIC_MODS which has just the built-in fortran intrinsic mods. Then near the bit of code that I fixed in correlate (~line 193), it does
`non_local_mods = INTRINSIC_MODS`

If extra_mods are supplied, it adds them to non_local_mods which actually adds them to the module variable INTRINSIC_MODS too because of python name binding. This isn't a problem if this is run on just a single project but it is probably a bug. 