### PR TITLE
Enable aliases in docstrings

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -620,18 +620,6 @@ def main(proj_data, proj_docs, md):
         )
         sys.exit(1)
 
-    # Convert the documentation from Markdown to HTML. Make sure to properly
-    # handle LateX and metadata.
-    if proj_data["relative"]:
-        project.markdown(md, "..")
-    else:
-        project.markdown(md, proj_data["project_url"])
-    project.correlate()
-    if proj_data["relative"]:
-        project.make_links("..")
-    else:
-        project.make_links(proj_data["project_url"])
-
     # Define core macros:
     ford.utils.register_macro("url = {0}".format(proj_data["project_url"]))
     ford.utils.register_macro(
@@ -644,6 +632,18 @@ def main(proj_data, proj_docs, md):
     # Register the user defined aliases:
     for alias in proj_data["alias"]:
         ford.utils.register_macro(alias)
+
+    # Convert the documentation from Markdown to HTML. Make sure to properly
+    # handle LateX and metadata.
+    if proj_data["relative"]:
+        project.markdown(md, "..")
+    else:
+        project.markdown(md, proj_data["project_url"])
+    project.correlate()
+    if proj_data["relative"]:
+        project.make_links("..")
+    else:
+        project.make_links(proj_data["project_url"])
 
     # Convert summaries and descriptions to HTML
     if proj_data["relative"]:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,34 @@
+import copy
+import ford
+import pathlib
 import pytest
+from textwrap import dedent
+
+# Ford default src folder
+DEFAULT_SRC = "src"
+
+
+def copy_file(data: str, path: pathlib.Path, filename: str) -> pathlib.Path:
+    """Write data to 'path/filename'"""
+    path.mkdir(exist_ok=True)
+    full_filename = path / filename
+    with open(full_filename, "w") as f:
+        f.write(dedent(data))
+    return full_filename
 
 
 @pytest.fixture
 def copy_fortran_file(tmp_path):
-    def copy_file(data):
-        filename = tmp_path / "test.f90"
-        with open(filename, "w") as f:
-            f.write(data)
-        return filename
-    return copy_file
+    return lambda data: copy_file(data, tmp_path / "src", "test.f90")
+
+
+@pytest.fixture
+def copy_settings_file(tmp_path):
+    return lambda data: copy_file(data, tmp_path, "test.md")
+
+
+@pytest.fixture
+def restore_macros():
+    old_macros = copy.copy(ford.utils._MACRO_DICT)
+    yield
+    ford.utils._MACRO_DICT = copy.copy(old_macros)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,3 +32,9 @@ def restore_macros():
     old_macros = copy.copy(ford.utils._MACRO_DICT)
     yield
     ford.utils._MACRO_DICT = copy.copy(old_macros)
+
+
+@pytest.fixture
+def restore_nameselector():
+    yield
+    ford.sourceform.namelist = ford.sourceform.NameSelector()

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -1,65 +1,44 @@
 import sys
-import pytest
-from collections import defaultdict
 import ford
 import ford.fortran_project
 
 # Ford default src folder
 DEFAULT_SRC = "src"
 
-@pytest.fixture
-def copy_fortran_file(tmp_path):
-    def copy_file(fortran_data):
-        src_dir = tmp_path / DEFAULT_SRC
-        src_dir.mkdir()
-        filename = src_dir / "test.f90"
-        with open(filename, "w") as f:
-            f.write(fortran_data)
-        return src_dir
-    return copy_file
 
-@pytest.fixture
-def copy_settings_file(tmp_path):
-    def copy_settings(data):
-        md_file = tmp_path / "ford.md"
-        with open(md_file, "w") as f:
-            f.write(data)
-        return md_file
-    return copy_settings
-
-
-
-import warnings
-
-def test_extra_mods_empty(copy_fortran_file, copy_settings_file, monkeypatch, tmp_path):
+def test_extra_mods_empty(
+    copy_fortran_file, copy_settings_file, monkeypatch, restore_macros
+):
     """This checks that extra_mods is parsed correctly in input md file"""
 
     data = """\
-module test
-end module test
-"""
+    module test
+    end module test
+    """
     settings = """\
-extra_mods:
-"""
+    extra_mods:
+    """
 
     copy_fortran_file(data)
     md_file = copy_settings_file(settings)
 
     # Modify command line args with argv to use
     with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ["ford", str(md_file)])
+        m.setattr(sys, "argv", ["ford", str(md_file)])
         ford.run()
 
 
-def test_extra_mods_intrinsic(copy_fortran_file, copy_settings_file, monkeypatch, tmp_path):
+def test_extra_mods_intrinsic(
+    copy_fortran_file, copy_settings_file, monkeypatch, restore_macros
+):
     """This checks that adding extra_mods doesn't change the module variable INTRINSIC_MODS"""
     data = """\
-module test
-end module test
-"""
+    module test
+    end module test
+    """
     settings = """\
-extra_mods: dummy: dummy_module
-"""
+    extra_mods: dummy: dummy_module
+    """
     # Initial value of intrinsic mods
     old_intrinsic_mods = ford.fortran_project.INTRINSIC_MODS.copy()
 
@@ -69,7 +48,7 @@ extra_mods: dummy: dummy_module
 
     # Modify command line args with argv to use
     with monkeypatch.context() as m:
-        m.setattr(sys, 'argv', ["ford", str(md_file)])
+        m.setattr(sys, "argv", ["ford", str(md_file)])
         ford.run()
 
     # Check that the module level variable has not been changed

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -1,13 +1,31 @@
+import pathlib
+import re
 import sys
+from typing import List
+
 import ford
 import ford.fortran_project
+
+from bs4 import BeautifulSoup
+
 
 # Ford default src folder
 DEFAULT_SRC = "src"
 
 
+def run_ford(monkeypatch, md_file: pathlib.Path):
+    """Modify command line args with argv"""
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", ["ford", str(md_file)])
+        ford.run()
+
+
 def test_extra_mods_empty(
-    copy_fortran_file, copy_settings_file, monkeypatch, restore_macros
+    copy_fortran_file,
+    copy_settings_file,
+    monkeypatch,
+    restore_macros,
+    restore_nameselector,
 ):
     """This checks that extra_mods is parsed correctly in input md file"""
 
@@ -23,14 +41,15 @@ def test_extra_mods_empty(
     copy_fortran_file(data)
     md_file = copy_settings_file(settings)
 
-    # Modify command line args with argv to use
-    with monkeypatch.context() as m:
-        m.setattr(sys, "argv", ["ford", str(md_file)])
-        ford.run()
+    run_ford(monkeypatch, md_file)
 
 
 def test_extra_mods_intrinsic(
-    copy_fortran_file, copy_settings_file, monkeypatch, restore_macros
+    copy_fortran_file,
+    copy_settings_file,
+    monkeypatch,
+    restore_macros,
+    restore_nameselector,
 ):
     """This checks that adding extra_mods doesn't change the module variable INTRINSIC_MODS"""
     data = """\
@@ -48,10 +67,153 @@ def test_extra_mods_intrinsic(
     copy_fortran_file(data)
     md_file = copy_settings_file(settings)
 
-    # Modify command line args with argv to use
-    with monkeypatch.context() as m:
-        m.setattr(sys, "argv", ["ford", str(md_file)])
-        ford.run()
+    run_ford(monkeypatch, md_file)
 
     # Check that the module level variable has not been changed
     assert ford.fortran_project.INTRINSIC_MODS == old_intrinsic_mods
+
+
+def get_main_body_text(html_dir: pathlib.Path, filename: str) -> List[str]:
+    with open(html_dir / filename, "r") as f:
+        index_html = BeautifulSoup(f.read(), features="html.parser")
+    return index_html.find_all(string=re.compile("Test:"))
+
+
+def test_default_aliases(
+    copy_fortran_file,
+    copy_settings_file,
+    tmp_path,
+    monkeypatch,
+    restore_macros,
+    restore_nameselector,
+):
+    """Check that aliases specified in project file are replaced correctly"""
+
+    data = """\
+    module test
+    !! Test: The project media url (|media|) should work here too
+    end module test
+    """
+    settings = """\
+    search: false
+
+    Test: The project media url should be |media|
+    """
+
+    copy_fortran_file(data)
+    md_file = copy_settings_file(settings)
+
+    run_ford(monkeypatch, md_file)
+
+    html_dir = tmp_path / "doc"
+    index_text = get_main_body_text(html_dir, "index.html")
+    expected_index_text = [
+        "Test: The project media url should be ./media",
+    ]
+    assert index_text == expected_index_text
+
+    module_text = get_main_body_text(html_dir, "module/test.html")
+    expected_module_text = [
+        "Test: The project media url (./media) should work here too"
+    ]
+    assert module_text == expected_module_text
+
+
+def test_one_alias(
+    copy_fortran_file,
+    copy_settings_file,
+    tmp_path,
+    monkeypatch,
+    restore_macros,
+    restore_nameselector,
+):
+    """Check that aliases specified in project file are replaced correctly"""
+
+    data = """\
+    module test
+    !! Title
+    !!
+    !! Test: This foo should not be exanded
+    !!
+    !! Test: But this |foo| should be 'bar'
+    end module test
+    """
+    settings = """\
+    search: false
+    alias: foo = bar
+
+    Test: This |foo| should be expanded as 'bar'
+
+    Test: This foo should not be.
+    """
+
+    copy_fortran_file(data)
+    md_file = copy_settings_file(settings)
+
+    run_ford(monkeypatch, md_file)
+
+    html_dir = tmp_path / "doc"
+    paragraphs = get_main_body_text(html_dir, "index.html")
+    expected_paragraphs = [
+        "Test: This bar should be expanded as 'bar'",
+        "Test: This foo should not be.",
+    ]
+    assert paragraphs == expected_paragraphs
+
+    module_text = get_main_body_text(html_dir, "module/test.html")
+    expected_module_text = [
+        "Test: This foo should not be exanded",
+        "Test: But this bar should be 'bar'",
+    ]
+    assert module_text == expected_module_text
+
+
+def test_multiple_aliases(
+    copy_fortran_file,
+    copy_settings_file,
+    tmp_path,
+    monkeypatch,
+    restore_macros,
+    restore_nameselector,
+):
+    """Check that aliases specified in project file are replaced correctly"""
+
+    data = """\
+    module test
+    !! Title
+    !!
+    !! Test: This foo and zing should not be exanded
+    !!
+    !! Test: But this |foo| should be 'bar', and this |zing| 'quaff'
+    end module test
+    """
+    settings = """\
+    search: false
+    alias: foo = bar
+           zing = quaff
+
+    Test: This |foo| should be expanded as 'bar', while |zing| should be 'quaff'
+
+    Test: This foo and zing should not be.
+    """
+
+    copy_fortran_file(data)
+    md_file = copy_settings_file(settings)
+
+    run_ford(monkeypatch, md_file)
+
+    html_dir = tmp_path / "doc"
+    paragraphs = get_main_body_text(html_dir, "index.html")
+    expected_paragraphs = [
+        "Test: This bar should be expanded as 'bar', while quaff should be 'quaff'",
+        "Test: This foo and zing should not be.",
+    ]
+
+    assert paragraphs == expected_paragraphs
+
+    module_text = get_main_body_text(html_dir, "module/test.html")
+    expected_module_text = [
+        "Test: This foo and zing should not be exanded",
+        "Test: But this bar should be 'bar', and this quaff 'quaff'",
+    ]
+    assert module_text == expected_module_text

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -16,6 +16,7 @@ def test_extra_mods_empty(
     end module test
     """
     settings = """\
+    search: false
     extra_mods:
     """
 
@@ -37,6 +38,7 @@ def test_extra_mods_intrinsic(
     end module test
     """
     settings = """\
+    search: false
     extra_mods: dummy: dummy_module
     """
     # Initial value of intrinsic mods

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,14 +1,6 @@
-import copy
 import pytest
 
 import ford
-
-
-@pytest.fixture
-def restore_macros():
-    old_macros = copy.copy(ford.utils._MACRO_DICT)
-    yield
-    ford.utils._MACRO_DICT = copy.copy(old_macros)
 
 
 def test_sub_macro(restore_macros):

--- a/test_data/external_project/external_project/doc.md
+++ b/test_data/external_project/external_project/doc.md
@@ -1,2 +1,3 @@
 project: external-project-1
+search: false
 externalize: true

--- a/test_data/external_project/top_level_project/doc.md
+++ b/test_data/external_project/top_level_project/doc.md
@@ -1,2 +1,3 @@
 project: top-level-project
+search: false
 external: exturl = ../external_project/doc


### PR DESCRIPTION
Aliases previously only worked in the main page and the "page" documentation, not in the source docstrings

A partial fix for #361 