### PR TITLE
add asterisks to list of mangled symbols

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -568,10 +568,10 @@ FORD will look in the provided paths for a modules.json file.
 
         # Check whether preprocessor works (reading nothing from stdin)
         try:
-            devnull = open(os.devnull)
-            subprocess.Popen(
-                preprocessor, stdin=devnull, stdout=devnull, stderr=devnull
-            ).communicate()
+            with open(os.devnull) as devnull:
+                subprocess.Popen(
+                    preprocessor, stdin=devnull, stdout=devnull, stderr=devnull
+                ).communicate()
         except OSError as ex:
             print("Warning: Testing preprocessor failed")
             print("  Preprocessor command: {}".format(preprocessor))

--- a/ford/fixed2free2.py
+++ b/ford/fixed2free2.py
@@ -132,10 +132,9 @@ def convertToFree(stream, length_limit=True):
 if __name__ == "__main__":
 
     if len(sys.argv) > 1:
-        infile = open(sys.argv[1], "r")
-        for line in convertToFree(infile):
-            print(line),
+        with open(sys.argv[1], "r") as infile:
+            for line in convertToFree(infile):
+                print(line)
 
-        infile.close()
     else:
         print(__doc__)

--- a/ford/output.py
+++ b/ford/output.py
@@ -287,9 +287,8 @@ class BasePage(object):
         return self.render(self.data, self.proj, self.obj)
 
     def writeout(self):
-        out = open(self.outfile, "wb")
-        out.write(self.html.encode("utf8"))
-        out.close()
+        with open(self.outfile, "wb") as out:
+            out.write(self.html.encode("utf8"))
 
     def render(self, data, proj, obj):
         """

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -3029,10 +3029,14 @@ class NameSelector(object):
             else:
                 num = 1
             self._counts[item.get_dir()][item.name] = num
-            name = item.name.lower().replace("<", "lt")
-            # name is already lower
-            name = name.replace(">", "gt")
-            name = name.replace("/", "SLASH")
+            name = item.name.lower()
+            for symbol, replacement in {
+                "<": "lt",
+                ">": "gt",
+                "/": "SLASH",
+                "*": "ASTERISK",
+            }.items():
+                name = name.replace(symbol, replacement)
             if name == "":
                 name = "__unnamed__"
             if num > 1:

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1425,8 +1425,8 @@ class FortranSourceFile(FortranContainer):
         )
 
         FortranContainer.__init__(self, source, "")
-        readobj = open(self.path, "r", encoding=settings["encoding"])
-        self.raw_src = readobj.read()
+        with open(self.path, "r", encoding=settings["encoding"]) as readobj:
+            self.raw_src = readobj.read()
         if self.fixed:
             self.src = highlight(
                 self.raw_src,

--- a/ford/tipue_search.py
+++ b/ford/tipue_search.py
@@ -105,6 +105,5 @@ class Tipue_Search_JSON_Generator(object):
         output = json.dumps(root_node, separators=(",", ":"), ensure_ascii=False)
         output = "var tipuesearch = " + output
 
-        out = open(path, "w", encoding="utf-8")
-        out.write(output)
-        out.close()
+        with open(path, "w", encoding="utf-8") as out:
+            out.write(output)


### PR DESCRIPTION
This PR is (mainly) narrowly focused on the edge case of ford having to write out a file such as `operator (*).html`, which python will complain about. 

It also replaces explicit file open and closes with context managers, aka "with statements", that ensure files get closed. These changes should be inoffensive and `pytest` was ran before and after the commits with the same failing test, so I hope I can sneak these changes in. 

---

For main thrust of this PR, consider this Fortran source code from an [Emory class on overloading operators](http://www.mathcs.emory.edu/~cheung/Courses/561/Syllabus/6-Fortran/operators.html) that defines the `*` operator between a matrix `A` and a vector `v`: 

```fortran
! ========================================================
! How to define your own operators in F90
! ========================================================

! --------------------------------------------------------
! (1) Write an ordinary matrix-vector multiply function
! --------------------------------------------------------
  function MatVecMult(A, v) result (w)
   implicit none

   real, dimension(:,:), INTENT(IN) :: A
   real, dimension(:), INTENT(IN) :: v
   real, dimension( SIZE(A,1) ) :: w

   integer :: i, j
   integer :: N

   N = size(v)

   w = 0.0       !! clear whole vector
   DO i = 1, N
      w = w + v(i) * A( :, i )
   END DO
  end function

! ==================================================================

  program Main
   implicit none

! -------------------------------------------------------------------------
! (2) This is how you turn an ordinary function into an operator function 
!
!     Make an interface with the name "operator *"
! -------------------------------------------------------------------------
   interface operator (*)
    function MatVecMult(A, v) result (w)
     real, dimension(:,:), INTENT(IN) :: A
     real, dimension(:), INTENT(IN) :: v
     real, dimension( SIZE(A,1) ) :: w
    end function
   end interface 

   real, dimension( 3, 3 ) :: A
   real, dimension( 3 ) :: v1, v2
   integer :: i, j

   CALL random_number( A )
   CALL random_number( v1 )

   v2 = A * v1

   DO i = 1, SIZE(A(:, 1))
      WRITE (6, '("[")', ADVANCE="NO")
      DO j = 1, SIZE(A(1, :))
         WRITE (6, '(2X F6.4)', ADVANCE="NO")   A(i,j)
      END DO
      WRITE (6, '("]")', ADVANCE="NO")

      WRITE (6, '(6X "[" F6.4 "]")', ADVANCE="NO")   v1(i)
      WRITE (6, '(6X "[" F6.4 "]")', ADVANCE="NO")   v2(i)
      print *
   END DO
   print *
   print *

  end program
```
<sup>[source](http://www.mathcs.emory.edu/~cheung/Courses/561/Syllabus/6-Fortran/Progs/operator-func02.f90)</sup>

This compiles with `gfortran filename.f90`, but running ford on this source in Windows produces an `OSError` because Python does not allow you to write out filenames with asterisks:
```python
OSError: [Errno 22] Invalid argument: '($repo_root)\\doc\\interface\\operator (*).html'
```
---
The proposed change merely mangles references to `*` with `ASTERISK` in the same fashion that `/` is mangled to `SLASH` and cleans up that section slightly. This solves my immediate issue and hopefully sidesteps any errors on other OSes related to wildcards in filenames. 