### PR TITLE
deps: need `importlib-metadata`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ bs4
 graphviz
 pygments
 jinja2
+importlib-metadata


### PR DESCRIPTION
Looks like ford runtime needs `importlib-metadata` otherwise it would report the following runtime error

```
  ==> /usr/local/Cellar/ford/6.1.6/bin/ford /private/tmp/ford-test-20220106-65625-7mgpnh/test-project.md
  Traceback (most recent call last):
    File "/usr/local/Cellar/ford/6.1.6/bin/ford", line 5, in <module>
      from ford import run
    File "/usr/local/Cellar/ford/6.1.6/libexec/lib/python3.9/site-packages/ford/__init__.py", line 30, in <module>
      import markdown
    File "/usr/local/Cellar/ford/6.1.6/libexec/lib/python3.9/site-packages/markdown/__init__.py", line 29, in <module>
      from .core import Markdown, markdown, markdownFromFile  # noqa: E402
    File "/usr/local/Cellar/ford/6.1.6/libexec/lib/python3.9/site-packages/markdown/core.py", line 26, in <module>
      from . import util
    File "/usr/local/Cellar/ford/6.1.6/libexec/lib/python3.9/site-packages/markdown/util.py", line 36, in <module>
      import importlib_metadata as metadata
  ModuleNotFoundError: No module named 'importlib_metadata'
```

- relates to https://github.com/Homebrew/homebrew-core/pull/92937
