### PR TITLE
Fix local external project

### DIFF
--- a/test_data/external_project/top_level_project/doc.md
+++ b/test_data/external_project/top_level_project/doc.md
@@ -1,3 +1,4 @@
 project: top-level-project
 search: false
-external: exturl = ../external_project/doc
+external: local = ../external_project/doc
+          remote = https://geb.sts.nt.uni-siegen.de/doxy/aotus

--- a/test_data/external_project/top_level_project/src/top_level.f90
+++ b/test_data/external_project/top_level_project/src/top_level.f90
@@ -1,5 +1,8 @@
 program top_level
+  !! This program uses a module from some external source, whose
+  !! documentation will be linked to from this documentation
   use external_module
+  use aot_out_module
   implicit none
   call external_sub
 end program top_level


### PR DESCRIPTION
When using external projects, a relative path in the url would not be resolved correctly, and so the resulting documentation would only be viewable from the correct directory. The existing test didn't catch this because it checked the documentation from the expected directory.