### PR TITLE
Add CSS for zebra rows to markdown tables

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -39,6 +39,7 @@ import ford.fortran_project
 import ford.sourceform
 import ford.output
 from ford.mdx_math import MathExtension
+from ford.md_table import ZebraTableCSSExtension
 import ford.utils
 import ford.pagetree
 
@@ -302,6 +303,7 @@ def parse_arguments(
         "markdown.extensions.codehilite",
         "markdown.extensions.extra",
         MathExtension(),
+        ZebraTableCSSExtension(),
         "md_environ.environ",
     ]
     md = markdown.Markdown(

--- a/ford/md_table.py
+++ b/ford/md_table.py
@@ -1,0 +1,28 @@
+from markdown import Markdown, Extension
+from markdown.treeprocessors import Treeprocessor
+from itertools import cycle
+
+
+def makeExtension(**kwargs):
+    return ZebraTableCSSExtension(**kwargs)
+
+
+class ZebraTableCSSExtension(Extension):
+    """Add CSS class to alternate rows in table"""
+
+    def extendMarkdown(self, md: Markdown, *args, **kwargs):
+        md.treeprocessors.register(ZebraTableCSSTreeprocessor(md), "table_css", 100)
+        md.registerExtension(self)
+
+
+class ZebraTableCSSTreeprocessor(Treeprocessor):
+    def run(self, root):
+        for element in root.iter():
+            if element.tag == "table":
+                element.set("class", "table")
+
+                rows = element.find("tbody").findall("tr")
+                zebra_cycler = cycle(["active", ""])
+
+                for row, style in zip(rows, zebra_cycler):
+                    row.set("class", style)

--- a/test/test_md_table.py
+++ b/test/test_md_table.py
@@ -1,0 +1,89 @@
+from ford.md_table import ZebraTableCSSExtension
+import markdown
+from bs4 import BeautifulSoup
+import textwrap
+
+
+def test_zebra_table():
+    """Check that alternate rows have different classes"""
+    md = markdown.Markdown(
+        extensions=["markdown.extensions.extra", ZebraTableCSSExtension()],
+        output_format="html5",
+    )
+
+    text = textwrap.dedent(
+        """
+        | Header1    | Header2     |
+        | ---------- | ----------- |
+        | some text  | some text   |
+        | some text  | some text   |
+        | some text  | some text   |
+        | some text  | some text   |
+        """
+    )
+
+    html = md.convert(text)
+    soup = BeautifulSoup(html, features="html.parser")
+
+    print(soup)
+    assert "table" in soup.table.attrs["class"]
+
+    body = soup.table.find("tbody")
+    rows = body.find_all("tr")
+    assert "active" in rows[0].attrs["class"]
+    assert "active" in rows[2].attrs["class"]
+
+    assert "active" not in rows[1].attrs["class"]
+    assert "active" not in rows[3].attrs["class"]
+
+
+def test_no_clobber_html_table():
+    """Check that tables with CSS already applied don't get modified"""
+    md = markdown.Markdown(
+        extensions=["markdown.extensions.extra", ZebraTableCSSExtension()],
+        output_format="html5",
+    )
+
+    text = textwrap.dedent(
+        """
+        <table class="dont-touch">
+        <thead>
+        <tr>
+        <th>Header1</th>
+        <th>Header2</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr class="row1">
+        <td>some text</td>
+        <td>some text</td>
+        </tr>
+        <tr class="row2">
+        <td>some text</td>
+        <td>some text</td>
+        </tr>
+        <tr class="row3">
+        <td>some text</td>
+        <td>some text</td>
+        </tr>
+        <tr class="row4">
+        <td>some text</td>
+        <td>some text</td>
+        </tr>
+        </tbody>
+        </table>
+        """
+    )
+
+    html = md.convert(text)
+    soup = BeautifulSoup(html, features="html.parser")
+
+    print(soup)
+    assert soup.table.attrs["class"] == ["dont-touch"]
+
+    body = soup.table.find("tbody")
+    rows = body.find_all("tr")
+    assert rows[0].attrs["class"] == ["row1"]
+    assert rows[1].attrs["class"] == ["row2"]
+    assert rows[2].attrs["class"] == ["row3"]
+    assert rows[3].attrs["class"] == ["row4"]


### PR DESCRIPTION
Note that this will apply to _all_ tables encountered in processing markdown files, except for raw HTML tables

Fixes #373 