### PR TITLE
Fix `type` permission attributes

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -663,10 +663,14 @@ class FortranContainer(FortranBase):
                 )
                 search_from += QUOTES_RE.search(line[search_from:]).end(0)
 
-            # Check the various possibilities for what is on this line
+            # Cache the lowercased line
+            line_lower = line.lower()
+
             if self.settings["lower"]:
-                line = line.lower()
-            if line.lower() == "contains":
+                line = line_lower
+
+            # Check the various possibilities for what is on this line
+            if line_lower == "contains":
                 if not incontains and type(self) in _can_have_contains:
                     incontains = True
                     if isinstance(self, FortranType):
@@ -682,10 +686,10 @@ class FortranContainer(FortranBase):
                             type(self).__name__[7:].upper()
                         ),
                     )
-            elif line.lower() in ["public", "private", "protected"]:
+            elif line_lower in ["public", "private", "protected"]:
                 if not isinstance(self, FortranType):
-                    self.permission = line.lower()
-            elif line.lower() == "sequence":
+                    self.permission = line_lower
+            elif line_lower == "sequence":
                 if type(self) == FortranType:
                     self.sequence = True
             elif self.FORMAT_RE.match(line):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1266,7 +1266,7 @@ class FortranCodeUnit(FortranContainer):
             "functions", "subroutines", "types", "interfaces", "absinterfaces"
         ):
             for attr in self.attr_dict[item.name.lower()]:
-                if attr == "public" or attr == "private" or attr == "protected":
+                if attr in ["public", "private", "protected"]:
                     item.permission = attr
                 elif attr[0:4] == "bind":
                     if hasattr(item, "bindC"):
@@ -1284,7 +1284,7 @@ class FortranCodeUnit(FortranContainer):
 
         for var in self.variables:
             for attr in self.attr_dict[var.name.lower()]:
-                if attr == "public" or attr == "private" or attr == "protected":
+                if attr in ["public", "private", "protected"]:
                     var.permission = attr
                 elif attr[0:6] == "intent":
                     var.intent = attr[7:-1]
@@ -1889,13 +1889,12 @@ class FortranType(FortranContainer):
             attribstr = line.group(1)[1:].strip()
             attriblist = self.SPLIT_RE.split(attribstr.strip())
             for attrib in attriblist:
+                attrib_lower = attrib.strip().lower()
                 if EXTENDS_RE.search(attrib):
                     self.extends = EXTENDS_RE.search(attrib).group(1)
-                elif attrib.strip().lower() == "public":
-                    self.permission = "public"
-                elif attrib.strip().lower() == "private":
-                    self.permission = "private"
-                elif attrib.strip().lower() == "external":
+                elif attrib_lower in ["public", "private"]:
+                    self.permission = attrib_lower
+                elif attrib_lower == "external":
                     self.attributes.append("external")
                 else:
                     self.attributes.append(attrib.strip())

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -636,8 +636,6 @@ class FortranContainer(FortranBase):
         incontains = False
         if type(self) is FortranSubmodule:
             self.permission = "private"
-        else:
-            self.permission = inherited_permission
 
         typestr = ""
         for vtype in self.settings["extra_vartypes"]:
@@ -684,12 +682,9 @@ class FortranContainer(FortranBase):
                             type(self).__name__[7:].upper()
                         ),
                     )
-            elif line.lower() == "public":
-                self.permission = "public"
-            elif line.lower() == "private":
-                self.permission = "private"
-            elif line.lower() == "protected":
-                self.permission = "protected"
+            elif line.lower() in ["public", "private", "protected"]:
+                if not isinstance(self, FortranType):
+                    self.permission = line.lower()
             elif line.lower() == "sequence":
                 if type(self) == FortranType:
                     self.sequence = True
@@ -1409,6 +1404,7 @@ class FortranSourceFile(FortranContainer):
         self.obj = "sourcefile"
         self.display = settings["display"]
         self.encoding = kwargs.get("encoding", True)
+        self.permission = "public"
 
         source = ford.reader.FortranReader(
             self.path,


### PR DESCRIPTION
Fixes #388 

The issue was type declarations like

```fortran
type, public :: foo
  private
  integer :: bar
end type foo
```

the `private` statement, which is only meant to apply to the type's members, was clobbering the type's permission