### PR TITLE
Fix for preprocessors that can't read from stdin

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -509,9 +509,9 @@ def parse_arguments(
         # Check whether preprocessor works (reading nothing from stdin)
         try:
             subprocess.run(
-                proj_data["preprocessor"],
+                proj_data["preprocessor"] + [os.devnull],
                 check=True,
-                stdin=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
             )
         except (subprocess.CalledProcessError, OSError) as ex:

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -110,9 +110,11 @@ def test_no_preprocessor():
 
 
 def test_bad_preprocessor():
-    data, _, _ = ford.parse_arguments({}, "preprocessor: false")
+    class FakeFile:
+        name = "test file"
 
-    assert data["preprocess"] is False
+    with pytest.raises(SystemExit):
+        ford.parse_arguments({"project_file": FakeFile()}, "preprocessor: false")
 
 
 def test_maybe_ok_preprocessor():

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -1,6 +1,7 @@
 import ford
 from textwrap import dedent
 import pytest
+import subprocess
 
 
 def test_quiet_false():
@@ -120,3 +121,18 @@ def test_maybe_ok_preprocessor():
     if data["preprocess"] is True:
         assert isinstance(data["preprocessor"], list)
         assert len(data["preprocessor"]) > 0
+
+
+def gfortran_is_not_installed():
+    """Returns False if gfortran is not (detectably) installed"""
+    out = subprocess.run("command -v gfortran", shell=True, check=False)
+    return out.returncode != 0
+
+
+@pytest.mark.skipif(
+    gfortran_is_not_installed(), reason="Requires gfortran to be installed"
+)
+def test_gfortran_preprocessor():
+    data, _, _ = ford.parse_arguments({}, "preprocessor: gfortran -E")
+
+    assert data["preprocess"] is True


### PR DESCRIPTION
Fixes #389, #398

`gfortran -E` requires a special flag to read from `stdin`, so instead
pass `/dev/null` as a filename. This _should_ be more robust -- at
least, this is how we call the preprocessor elsewhere.

This might fail in other ways for other preprocessors. For instance,
`gfortran -E` emits a warning instead of a preprocessed stream when
passed `/dev/null` like this. It might be necessary to pass an empty
file instead. We also still don't check that flags/macros are passed correctly.

Also now immediately aborts with a helpful error message if the preprocessor check fails