### PR TITLE
External projects: deal with extended types

### DIFF
--- a/ford/utils.py
+++ b/ford/utils.py
@@ -395,7 +395,7 @@ def external(project, make=False, path="."):
         if hasattr(intObj, "proctype"):
             extDict["proctype"] = intObj.proctype
         if hasattr(intObj, "extends"):
-            if type(intObj.extends) == ford.sourceform.FortranType:
+            if isinstance(intObj.extends, ford.sourceform.FortranType):
                 extDict["extends"] = obj2dict(intObj.extends)
             else:
                 extDict["extends"] = intObj.extends

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -395,7 +395,10 @@ def external(project, make=False, path="."):
         if hasattr(intObj, "proctype"):
             extDict["proctype"] = intObj.proctype
         if hasattr(intObj, "extends"):
-            extDict["extends"] = intObj.extends
+            if type(intObj.extends) == ford.sourceform.FortranType:
+                extDict["extends"] = obj2dict(intObj.extends)
+            else:
+                extDict["extends"] = intObj.extends
         for attrib in attribs:
             if hasattr(intObj, attrib):
                 if type(getattr(intObj, attrib)) == str:

--- a/test_data/external_project/external_project/src/external.f90
+++ b/test_data/external_project/external_project/src/external.f90
@@ -1,5 +1,14 @@
 module external_module
   implicit none
+
+  type basis
+    integer :: id
+  end type basis
+
+  type, extends(basis) :: test
+    logical :: ok
+  end type
+
 contains
   subroutine external_sub
   end subroutine external_sub


### PR DESCRIPTION
There is an issue with extended types when creating the serialization of objects for the json database. The extends property holds a `FortranType`, which json does not know how to serialize. Hence, we need to do an obj2dict for this attribute.

This change also expands the `external_project` in the `test_data` to include an extended type.