### PR TITLE
Fix for `FortranVariable` sharing references to lists

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2208,18 +2208,20 @@ class FortranVariable(FortranBase):
         self.hierarchy.reverse()
 
     def correlate(self, project):
-        if (
-            (self.vartype == "type" or self.vartype == "class")
-            and self.proto
-            and self.proto[0] != "*"
-        ):
-            if self.proto[0].lower() in self.parent.all_types:
-                self.proto[0] = self.parent.all_types[self.proto[0].lower()]
-        elif self.vartype == "procedure" and self.proto and self.proto[0] != "*":
-            if self.proto[0].lower() in self.parent.all_procs:
-                self.proto[0] = self.parent.all_procs[self.proto[0].lower()]
-            elif self.proto[0].lower() in self.parent.all_absinterfaces:
-                self.proto[0] = self.parent.all_absinterfaces[self.proto[0].lower()]
+        if not self.proto:
+            return
+
+        proto_name = self.proto[0].lower()
+        if proto_name == "*":
+            return
+
+        if self.vartype in ("type", "class"):
+            self.proto[0] = self.parent.all_types.get(proto_name, self.proto[0])
+        elif self.vartype == "procedure":
+            abstract_prototype = self.parent.all_absinterfaces.get(
+                proto_name, self.proto[0]
+            )
+            self.proto[0] = self.parent.all_procs.get(proto_name, abstract_prototype)
 
 
 class FortranBoundProcedure(FortranBase):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2156,7 +2156,7 @@ class FortranVariable(FortranBase):
         kind=None,
         strlen=None,
         proto=None,
-        doc=[],
+        doc=None,
         points=False,
         initial=None,
     ):
@@ -2170,17 +2170,16 @@ class FortranVariable(FortranBase):
             self.parobj = None
             self.settings = None
         self.obj = type(self).__name__[7:].lower()
-        self.attribs = attribs
+        self.attribs = copy.copy(attribs)
         self.intent = intent
         self.optional = optional
         self.kind = kind
         self.strlen = strlen
         self.proto = copy.copy(proto)
-        self.doc = doc
+        self.doc = copy.copy(doc) or []
         self.permission = permission
         self.points = points
         self.parameter = parameter
-        self.doc = []
         self.initial = initial
         self.dimension = ""
         self.meta = {}
@@ -2725,6 +2724,14 @@ def line_to_variables(source, line, inherit_permission, parent):
         declarestr = ATTRIBSPLIT2_RE.match(rest).group(2)
     declarations = ford.utils.paren_split(",", declarestr)
 
+    doc = []
+    docline = next(source)
+    docmark = f"!{parent.settings['docmark']}"
+    while docline.startswith(docmark):
+        doc.append(docline[2:])
+        docline = next(source)
+    source.pass_back(docline)
+
     varlist = []
     for dec in declarations:
         dec = re.sub(" ", "", dec)
@@ -2767,20 +2774,12 @@ def line_to_variables(source, line, inherit_permission, parent):
                 kind,
                 strlen,
                 proto,
-                [],
+                doc,
                 points,
                 initial,
             )
         )
 
-    doc = []
-    docline = next(source)
-    while docline[0:2] == "!" + parent.settings["docmark"]:
-        doc.append(docline[2:])
-        docline = next(source)
-    source.pass_back(docline)
-    for var in varlist:
-        var.doc = doc
     return varlist
 
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2175,7 +2175,7 @@ class FortranVariable(FortranBase):
         self.optional = optional
         self.kind = kind
         self.strlen = strlen
-        self.proto = proto
+        self.proto = copy.copy(proto)
         self.doc = doc
         self.permission = permission
         self.points = points

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -538,6 +538,23 @@ def test_display_private_derived_types(copy_fortran_file):
     assert type_names == {"no_attrs", "public_attr", "private_attr"}
 
 
+def test_interface_type_name(copy_fortran_file):
+    """Check for shared prototype list"""
+    data = """\
+    module foo
+      type name_t
+      end type name_t
+
+      type(name_t) :: var, var2
+    end module foo
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+    proto_names = [var.proto[0].name for var in project.modules[0].variables]
+    assert proto_names == ["name_t", "name_t"]
+
+
 def test_display_internal_procedures(copy_fortran_file):
     """_very_ basic test of 'proc_internals' setting"""
 

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -555,6 +555,73 @@ def test_interface_type_name(copy_fortran_file):
     assert proto_names == ["name_t", "name_t"]
 
 
+def test_imported_interface_type_name(copy_fortran_file):
+    """Check for shared prototype list"""
+    data = """\
+    module foo
+      type name_t
+      end type name_t
+    end module foo
+
+    module bar
+      use foo
+      type(name_t), allocatable :: var(:), var2(:)
+    end module bar
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+    proto_names = [var.proto[0].name for var in project.modules[1].variables]
+    assert proto_names == ["name_t", "name_t"]
+
+
+def test_abstract_interface_type_name(copy_fortran_file):
+    """Check for shared prototype list"""
+    data = """\
+    module foo
+      abstract interface
+        subroutine hello
+        end subroutine hello
+      end interface
+
+      procedure(hello) :: proc1, proc2
+    end module foo
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+    proto_names = [var.proto[0].name for var in project.modules[0].variables]
+    assert proto_names == ["hello", "hello"]
+
+
+def test_imported_abstract_interface_type_name(copy_fortran_file):
+    """Check for shared prototype list"""
+    data = """\
+    module foo
+      abstract interface
+        subroutine hello
+        end subroutine hello
+      end interface
+
+    contains
+      integer function goodbye()
+        goodbye = 1
+      end function goodbye
+    end module foo
+
+    module bar
+      use foo
+      procedure(hello) :: proc1, proc2
+      procedure(goodbye) :: proc3, proc4
+    end module bar
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+    proto_names = [var.proto[0].name for var in project.modules[1].variables]
+    assert proto_names == ["hello", "hello", "goodbye", "goodbye"]
+
+
 def test_display_internal_procedures(copy_fortran_file):
     """_very_ basic test of 'proc_internals' setting"""
 

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -811,31 +811,33 @@ class FakeVariable:
             "type(foo) :: bar = 42",
             [FakeVariable("bar", "type", proto=["foo", ""], initial="42")],
         ),
+        (
+            "class(foo) :: var1, var2",
+            [
+                FakeVariable("var1", "class", proto=["foo", ""]),
+                FakeVariable("var2", "class", proto=["foo", ""]),
+            ],
+        ),
     ],
 )
 def test_line_to_variable(line, expected_variables):
     variables = line_to_variables(FakeSource(), line, "public", FakeParent())
+    attributes = expected_variables[0].__dict__
 
     for variable, expected in zip(variables, expected_variables):
-        for attr in [
-            "name",
-            "vartype",
-            "parent",
-            "attribs",
-            "intent",
-            "optional",
-            "permission",
-            "parameter",
-            "kind",
-            "strlen",
-            "proto",
-            "doc",
-            "points",
-            "initial",
-        ]:
+        for attr in attributes:
             variable_attr = getattr(variable, attr)
             expected_attr = getattr(expected, attr)
             assert variable_attr == expected_attr, attr
+
+    if len(expected_variables) > 1:
+        attributes.pop("parent")
+        for attr in attributes:
+            attribute = getattr(variable, attr)
+            if not isinstance(attribute, list):
+                continue
+            proto_ids = [id(getattr(variable, attr)) for variable in variables]
+            assert len(proto_ids) == len(set(proto_ids)), attr
 
 
 def test_markdown_header_bug286(parse_fortran_file):

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -818,6 +818,10 @@ class FakeVariable:
                 FakeVariable("var2", "class", proto=["foo", ""]),
             ],
         ),
+        (
+            "class(*) :: polymorphic",
+            [FakeVariable("polymorphic", "class", proto=["*", ""])],
+        ),
     ],
 )
 def test_line_to_variable(line, expected_variables):


### PR DESCRIPTION
Fixes #399 