### PR TITLE
Fix change to `exclude` behaviour

### DIFF
--- a/example/example-project-file.md
+++ b/example/example-project-file.md
@@ -27,7 +27,7 @@ extra_mods: json_module: http://jacobwilliams.github.io/json-fortran/
 license: by-nc
 extra_filetypes: sh #
 max_frontpage_items: 4
-exclude: src/excluded_file.f90
+exclude: excluded_file.f90
 exclude_dir: src/excluded_directory
 ---
 

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -443,7 +443,6 @@ def parse_arguments(
         "css",
         "mathjax_config",
         "src_dir",
-        "exclude",
         "exclude_dir",
         "include",
     ]:

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -82,7 +82,7 @@ class Project(object):
         srcdir_list = self.make_srcdir_list(settings["exclude_dir"])
         for curdir in srcdir_list:
             for item in [f for f in curdir.iterdir() if f.is_file()]:
-                if item in settings["exclude"]:
+                if item.name in settings["exclude"]:
                     continue
 
                 filename = curdir / item

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -685,7 +685,7 @@ def test_exclude(tmp_path):
 
     settings = deepcopy(DEFAULT_SETTINGS)
     settings["src_dir"] = [tmp_path]
-    settings["exclude"] = [normalise_path(tmp_path, "sub1/sub2/exclude.f90")]
+    settings["exclude"] = ["exclude.f90"]
     project = Project(settings)
 
     program_names = {program.name for program in project.programs}


### PR DESCRIPTION
Fixes #407

`exclude` excludes files based solely on name and not path. 336075c changed this to exclude based on path instead