### PR TITLE
Do not fail on existing MathJax-config directory

### DIFF
--- a/ford/output.py
+++ b/ford/output.py
@@ -249,12 +249,15 @@ class Documentation(object):
                 shutil.copy(src.path, os.path.join(out_dir, "src", src.name))
 
         if "mathjax_config" in self.data:
-            mathjax_path = os.mkdir(os.path.join(out_dir, "js", "MathJax-config"))
-            if not os.path.join(mathjax_config):
-                os.mkdir(mathjax_config)
+            mathjax_path = os.path.join(out_dir, "js", "MathJax-config")
+            if not os.path.isdir(mathjax_path):
+                os.mkdir(mathjax_path)
             shutil.copy(
                 self.data["mathjax_config"],
-                os.path.join(mathjax_config, os.path.basename(self.data["mathjax_config"])),
+                os.path.join(
+                    mathjax_path,
+                    os.path.basename(self.data["mathjax_config"])
+                ),
             )
         # By doing this we omit a duplication of data.
         for p in self.docs:

--- a/ford/output.py
+++ b/ford/output.py
@@ -250,12 +250,11 @@ class Documentation(object):
 
         if "mathjax_config" in self.data:
             mathjax_path = os.mkdir(os.path.join(out_dir, "js", "MathJax-config"))
-            if not os.path.join(mathjax_config)
+            if not os.path.join(mathjax_config):
                 os.mkdir(mathjax_config)
             shutil.copy(
                 self.data["mathjax_config"],
-                os.path.join(mathjax_config, os.path.basename(self.data["mathjax_config"]),
-                ),
+                os.path.join(mathjax_config, os.path.basename(self.data["mathjax_config"])),
             )
         # By doing this we omit a duplication of data.
         for p in self.docs:

--- a/ford/output.py
+++ b/ford/output.py
@@ -249,14 +249,12 @@ class Documentation(object):
                 shutil.copy(src.path, os.path.join(out_dir, "src", src.name))
 
         if "mathjax_config" in self.data:
-            os.mkdir(os.path.join(out_dir, "js", "MathJax-config"))
+            mathjax_path = os.mkdir(os.path.join(out_dir, "js", "MathJax-config"))
+            if not os.path.join(mathjax_config)
+                os.mkdir(mathjax_config)
             shutil.copy(
                 self.data["mathjax_config"],
-                os.path.join(
-                    out_dir,
-                    "js",
-                    "MathJax-config",
-                    os.path.basename(self.data["mathjax_config"]),
+                os.path.join(mathjax_config, os.path.basename(self.data["mathjax_config"]),
                 ),
             )
         # By doing this we omit a duplication of data.


### PR DESCRIPTION
Only create the directory MathJax-config when it doesn't exist yet. Avoids a crash with FileExistsError, which I don't see why it should be fatal.