### PR TITLE
External projects: Actually return the generated object in dict2obj

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -627,7 +627,8 @@ class FortranGraph(object):
             return False
         else:
             for n in nodes:
-                self.dot.node(n.ident, **n.attribs)
+                strattribs = {key: str(a) for key, a in n.attribs.items()}
+                self.dot.node(n.ident, **strattribs)
             for e in edges:
                 if len(e) == 5:
                     self.dot.edge(

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -485,6 +485,7 @@ def external(project, make=False, path="."):
                     for key2, item in extDict[key].items()
                 }
                 setattr(extObj, key, tmpDict)
+        return extObj
 
     if make:
         # convert internal module object to a JSON database

--- a/test_data/external_project/top_level_project/doc.md
+++ b/test_data/external_project/top_level_project/doc.md
@@ -1,4 +1,5 @@
 project: top-level-project
 search: false
+graph: true
 external: local = ../external_project/doc
           remote = https://example.com


### PR DESCRIPTION
In our project using an external subproject some links went missing, causing aborts of FORD, because some objects were unexpectedly `None`. The problem seems to be that `dict2obj` did not actually return the generated object sometimes. This led to the public lists of external modules containing keys with `None` values.

Returning the object in the recursive function seems to resolve this issue for me.