### PR TITLE
External: Fix extending external types with

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -306,6 +306,10 @@ class TypeNode(BaseNode):
         self.comp_types = dict()
         self.comp_of = dict()
         if not self.fromstr:
+            if hasattr(obj, "external_url"):
+                # Stop following chain, as this object is in an external project
+                return
+
             if obj.extends:
                 if obj.extends in hist:
                     self.ancestor = hist[obj.extends]
@@ -315,10 +319,6 @@ class TypeNode(BaseNode):
                     )
                 self.ancestor.children.add(self)
                 self.ancestor.visible = getattr(obj.extends, "visible", True)
-
-            if hasattr(obj, "external_url"):
-                # Stop following chain, as this object is in an external project
-                return
 
             for var in obj.local_variables:
                 if (var.vartype == "type" or var.vartype == "class") and var.proto[

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -627,7 +627,8 @@ class FortranGraph(object):
             return False
         else:
             for n in nodes:
-                self.dot.node(n.ident, **n.attribs)
+                strattribs = {key: str(a) for key, a in n.attribs.items()}
+                self.dot.node(n.ident, **strattribs)
             for e in edges:
                 if len(e) == 5:
                     self.dot.edge(

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -3031,6 +3031,7 @@ class ExternalInterface(FortranInterface):
         self.obj = "proc"
         self.proctype = "interface"
 
+
 class ExternalBoundProcedure(FortranBoundProcedure):
     _project_list = "extProcedures"
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -534,7 +534,7 @@ class FortranBase(object):
         Process intra-site links to documentation of other parts of the program.
         """
         self.doc = ford.utils.sub_links(self.doc, project)
-        if self.meta["summary"] is not None:
+        if self.meta.get("summary", None) is not None:
             self.meta["summary"] = ford.utils.sub_links(self.meta["summary"], project)
 
         # Create links in the project
@@ -553,7 +553,7 @@ class FortranBase(object):
             "args",
             "bindings",
         ):
-            if isinstance(item, FortranBase):
+            if isinstance(item, FortranBase) and hasattr(item, "doc"):
                 item.make_links(project)
         if hasattr(self, "retvar"):
             if self.retvar:
@@ -1959,6 +1959,10 @@ class FortranType(FortranContainer):
             if var.permission == "public"
         ]
         self.local_variables = self.variables
+        for invar in inherited:
+            if not hasattr(invar, 'doc'):
+                invar.doc = "Inherited from [[{0}]]".format(self.extends)
+                invar.meta = {}
         self.variables = inherited + self.variables
 
         # Match boundprocs with procedures

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -3036,6 +3036,7 @@ class ExternalType(FortranType):
         self.external_url = url
         self.parent = parent
         self.obj = "type"
+        self.boundprocs = []
 
 
 class ExternalVariable(FortranVariable):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1994,7 +1994,7 @@ class FortranType(FortranContainer):
         # Match up generic type-bound procedures to their particular bindings
         for proc in self.boundprocs:
             for bp in inherited_generic:
-                if bp.name.lower() == proc.name.lower():
+                if bp.name.lower() == proc.name.lower() and hasattr(bp, "bindings"):
                     proc.bindings = bp.bindings + proc.bindings
                     break
             if proc.generic:

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -3031,6 +3031,15 @@ class ExternalInterface(FortranInterface):
         self.obj = "proc"
         self.proctype = "interface"
 
+class ExternalBoundProcedure(FortranBoundProcedure):
+    _project_list = "extProcedures"
+
+    def __init__(self, name: str, url: str = "", parent=None):
+        self.name = name
+        self.external_url = url
+        self.parent = parent
+        self.obj = "proc"
+
 
 class ExternalType(FortranType):
     _project_list = "extTypes"

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -377,6 +377,7 @@ def external(project, make=False, path="."):
         ExternalInterface,
         ExternalType,
         ExternalVariable,
+        ExternalBoundProcedure,
     )
 
     # attributes of a module object needed for further processing
@@ -404,6 +405,7 @@ def external(project, make=False, path="."):
         "variable": ExternalVariable,
         "function": ExternalFunction,
         "subroutine": ExternalSubroutine,
+        "boundprocedure": ExternalBoundProcedure,
     }
 
     def obj2dict(intObj):

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -391,6 +391,7 @@ def external(project, make=False, path="."):
         "absinterfaces",
         "types",
         "variables",
+        "boundprocs",
     ]
 
     # Mapping between entity name and its type

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -392,6 +392,8 @@ def external(project, make=False, path="."):
         "types",
         "variables",
         "boundprocs",
+        "vartype",
+        "permission",
     ]
 
     # Mapping between entity name and its type

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -483,12 +483,15 @@ def external(project, make=False, path="."):
             if key not in extDict:
                 continue
             if isinstance(extDict[key], list):
-                tmpLs = [dict2obj(item, url, extObj, remote) for item in extDict[key] if item]
+                tmpLs = [
+                    dict2obj(item, url, extObj, remote) for item in extDict[key] if item
+                ]
                 setattr(extObj, key, tmpLs)
             elif isinstance(extDict[key], dict):
                 tmpDict = {
                     key2: dict2obj(item, url, extObj, remote)
-                    for key2, item in extDict[key].items() if item
+                    for key2, item in extDict[key].items()
+                    if item
                 }
                 setattr(extObj, key, tmpDict)
             else:

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -395,6 +395,7 @@ def external(project, make=False, path="."):
         "boundprocs",
         "vartype",
         "permission",
+        "generic",
     ]
 
     # Mapping between entity name and its type
@@ -430,12 +431,12 @@ def external(project, make=False, path="."):
 
             attribute = getattr(intObj, attrib)
 
-            if isinstance(attribute, str):
-                extDict[attrib] = attribute
-            elif isinstance(attribute, list):
+            if isinstance(attribute, list):
                 extDict[attrib] = [obj2dict(item) for item in attribute]
             elif isinstance(attribute, dict):
                 extDict[attrib] = {key: obj2dict(val) for key, val in attribute.items()}
+            else:
+                extDict[attrib] = str(attribute)
         return extDict
 
     def modules_from_local(url: pathlib.Path):
@@ -479,9 +480,7 @@ def external(project, make=False, path="."):
         for key in ATTRIBUTES:
             if key not in extDict:
                 continue
-            if isinstance(extDict[key], str):
-                setattr(extObj, key, extDict[key])
-            elif isinstance(extDict[key], list):
+            if isinstance(extDict[key], list):
                 tmpLs = [dict2obj(item, url, extObj, remote) for item in extDict[key]]
                 setattr(extObj, key, tmpLs)
             elif isinstance(extDict[key], dict):
@@ -490,6 +489,8 @@ def external(project, make=False, path="."):
                     for key2, item in extDict[key].items()
                 }
                 setattr(extObj, key, tmpDict)
+            else:
+                setattr(extObj, key, extDict[key])
         return extObj
 
     if make:

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -299,7 +299,7 @@ def sub_links(string, project):
 
             for obj in searchlist:
                 if match.group(3).lower() == obj.name.lower():
-                    url = url + "#" + obj.anchor
+                    url = str(url) + "#" + obj.anchor
                     name = obj.name
                     item = obj
                     break
@@ -413,6 +413,8 @@ def external(project, make=False, path="."):
         """
         Converts an object to a dictionary.
         """
+        if hasattr(intObj, "external_url"):
+            return None
         extDict = {
             "name": intObj.name,
             "external_url": intObj.get_url(),
@@ -481,12 +483,12 @@ def external(project, make=False, path="."):
             if key not in extDict:
                 continue
             if isinstance(extDict[key], list):
-                tmpLs = [dict2obj(item, url, extObj, remote) for item in extDict[key]]
+                tmpLs = [dict2obj(item, url, extObj, remote) for item in extDict[key] if item]
                 setattr(extObj, key, tmpLs)
             elif isinstance(extDict[key], dict):
                 tmpDict = {
                     key2: dict2obj(item, url, extObj, remote)
-                    for key2, item in extDict[key].items()
+                    for key2, item in extDict[key].items() if item
                 }
                 setattr(extObj, key, tmpDict)
             else:

--- a/test/test_projects/test_external_project.py
+++ b/test/test_projects/test_external_project.py
@@ -116,7 +116,7 @@ def test_external_project(copy_project_files, monkeypatch, restore_macros):
     uses_box = top_program_html.find(string="Uses").parent.parent.parent
     links = {tag.text: tag.a["href"] for tag in uses_box("li", class_=None)}
 
-    assert len(links) == 2
+    assert len(links) == 3
     assert "external_module" in links
     local_url = urlparse(links["external_module"])
     assert pathlib.Path(local_url.path).is_file()

--- a/test_data/external_project/external_project/src/external.f90
+++ b/test_data/external_project/external_project/src/external.f90
@@ -9,6 +9,29 @@ module external_module
     logical :: ok
   end type
 
+
+  type, abstract, public :: solverAborts_type
+  contains
+    procedure(load_aborts), deferred :: load
+  end type solverAborts_type
+
+
+  abstract interface
+
+    !> Loading additional parameters for solver specific abort criteria.
+    subroutine load_aborts(me, handle)
+      import solverAborts_type
+
+      !> The solver specific type to hold additional abort parameters.
+      class(solverAborts_type), intent(inout) :: me
+
+      !> Handle to configuration to load parameters from.
+      integer, intent(in) :: conf
+
+    end subroutine load_aborts
+
+  end interface
+
 contains
   subroutine external_sub
   end subroutine external_sub

--- a/test_data/external_project/top_level_project/doc.md
+++ b/test_data/external_project/top_level_project/doc.md
@@ -1,4 +1,5 @@
 project: top-level-project
 search: false
+graph: true
 external: local = ../external_project/doc
           remote = https://example.com

--- a/test_data/external_project/top_level_project/src/top_level.f90
+++ b/test_data/external_project/top_level_project/src/top_level.f90
@@ -1,8 +1,38 @@
+module myAbort
+  use external_module
+  type, public, extends(solverAborts_type) :: vel_abortCriteria_type
+
+    !> Maximal velocity that will be tolerated in the simulation.
+    real :: velmax = 0.15
+
+  contains
+
+    procedure :: load => abortCriteria_load
+
+  end type solverAborts_type
+
+contains
+
+  subroutine abortCriteria_load(me, conf)
+    ! -------------------------------------------------------------------- !
+    !> Object to hold the solver specific configuration parameters.
+    class(vel_abortCriteria_type), intent(inout) :: me
+
+    !> Handle to the configuration.
+    integer, intent(in) :: conf
+
+    me%velmax = real(conf)*0.15
+
+  end subroutine mus_abortCriteria_load
+
+end module myAbort
+
 program top_level
   !! This program uses a module from some external source, whose
   !! documentation will be linked to from this documentation
   use external_module
   use remote_module
+  use myAbort
 
   implicit none
 

--- a/test_data/external_project/top_level_project/src/top_level.f90
+++ b/test_data/external_project/top_level_project/src/top_level.f90
@@ -3,7 +3,13 @@ program top_level
   !! documentation will be linked to from this documentation
   use external_module
   use remote_module
+
   implicit none
+
+  type, extends(test) :: maintest
+    character(len=10) :: label
+  end type
+
   call external_sub
   call remote_sub
 end program top_level


### PR DESCRIPTION
There is another issue with external projects, when we try to extend a type that is defined in an external project, we fail for type bound procedures, as they do not get exported, and similarly also for public variables in that type. For variables I don't want to include the documentation in the json serialization. Instead I insert a text with a link to the type we inherit the variable from. This doesn't seem to be proper though, yet. Maybe it needs to go through Markdown processing first? The make_links works however. (The example in the testsuite is updated accordingly to cover this case)