### PR TITLE
Only fall back to unpreprocessed file if preprocessing fails

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ import ford
 import pathlib
 import pytest
 from textwrap import dedent
+import subprocess
 
 # Ford default src folder
 DEFAULT_SRC = "src"
@@ -19,7 +20,9 @@ def copy_file(data: str, path: pathlib.Path, filename: str) -> pathlib.Path:
 
 @pytest.fixture
 def copy_fortran_file(tmp_path):
-    return lambda data: copy_file(data, tmp_path / "src", "test.f90")
+    return lambda data, extension=".f90": copy_file(
+        data, tmp_path / "src", f"test{extension}"
+    )
 
 
 @pytest.fixture
@@ -38,3 +41,9 @@ def restore_macros():
 def restore_nameselector():
     yield
     ford.sourceform.namelist = ford.sourceform.NameSelector()
+
+
+def gfortran_is_not_installed():
+    """Returns False if gfortran is not (detectably) installed"""
+    out = subprocess.run("command -v gfortran", shell=True, check=False)
+    return out.returncode != 0

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -1,7 +1,8 @@
 import ford
 from textwrap import dedent
 import pytest
-import subprocess
+
+from conftest import gfortran_is_not_installed
 
 
 def test_quiet_false():
@@ -123,12 +124,6 @@ def test_maybe_ok_preprocessor():
     if data["preprocess"] is True:
         assert isinstance(data["preprocessor"], list)
         assert len(data["preprocessor"]) > 0
-
-
-def gfortran_is_not_installed():
-    """Returns False if gfortran is not (detectably) installed"""
-    out = subprocess.run("command -v gfortran", shell=True, check=False)
-    return out.returncode != 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fixes #423

Previously, if preprocessing emitted anything to stderr, we would fall
back to using the unpreprocessed file. Now we only do so if
preprocessing errors. Warnings are still reported