### PR TITLE
Update README with spack installation and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FORD
 [![Latest Version](https://img.shields.io/pypi/v/ford.svg)](https://pypi.python.org/pypi/FORD)
 [![Latest homebrew version](https://img.shields.io/homebrew/v/ford.svg?maxAge=2592000)](http://braumeister.org/formula/ford)
+[![Latest spack version](https://img.shields.io/spack/v/py-ford)](https://spack.readthedocs.io/en/latest/package_list.html#py-ford)
 [![GitHub license](https://img.shields.io/badge/license-GPL_v3-blue.svg)](./LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1422473.svg)](https://doi.org/10.5281/zenodo.1422473)
 
@@ -78,6 +79,10 @@ a terminal:
 
 If you would like to install the latest development (master) branch from github,
 simply add the `--HEAD` flag: `brew install --HEAD FORD`
+
+FORD is also available through the [spack](https://spack.readthedocs.io/en/latest/) package manager by running the following command:
+
+    spack install py-ford
 
 ## Documentation
 More complete documentation can be found in the [project wiki](https://github.com/Fortran-FOSS-Programmers/ford/wiki).

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,10 @@ a terminal:
 If you would like to install the latest development (master) branch from github,
 simply add the :code:`--HEAD` flag: :code:`brew install --HEAD FORD`
 
+FORD is also available through the `spack <https://spack.readthedocs.io/en/latest/>`__ package
+manager by running the following command:
+::
+    spack install py-ford
 
 Documentation
 -------------


### PR DESCRIPTION
I added FORD as a spack package and it was recently merged, so I added information and a version badge for installing FORD via spack package manager. 