### PR TITLE
Fix hang when creating graphs during writing documentation

### DIFF
--- a/ford/graphmanager.py
+++ b/ford/graphmanager.py
@@ -25,9 +25,9 @@
 import os
 import pathlib
 import sys
-from multiprocessing import Pool
 
 from tqdm import tqdm
+from tqdm.contrib.concurrent import process_map
 
 from ford.sourceform import (
     FortranFunction,
@@ -221,11 +221,12 @@ class GraphManager(object):
             )
             args.extend([(m.usesgraph, self.graphdir) for m in self.blockdata])
 
-            np = min(njobs, len(args))
-            pool = Pool(processes=np)
-            results = pool.map(outputFuncWrap, args, len(args) / np)  # noqa F841
-            pool.close()
-            pool.join()
+            process_map(
+                outputFuncWrap,
+                args,
+                max_workers=njobs,
+                desc="Writing graphs",
+            )
 
         if self.usegraph:
             self.usegraph.create_svg(self.graphdir)

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -260,7 +260,8 @@ class BaseNode(object):
         return self.ident == other.ident
 
     def __hash__(self):
-        return hash(self.ident)
+        """Hash required to insert into dict"""
+        return id(self)
 
 
 class ModNode(BaseNode):


### PR DESCRIPTION
Fixes #258
(and also #383 #411 )

Two part fix:

1. use `tqdm.contrib.concurrent.process_map` instead of
   `multiprocessing.Pool.map`. This crashes instead of hanging, which
   lets us see that we have a problem with...
2. `graphs.BaseNode.__hash__` uses `self.ident`, but this causes
   issues when unpickling, seemingly because `pickle` uses `hash` but
   also unpickles attributes in an unpredictable order

Added bonus that `tqdm.process_map` prints a progress bar as well