### PR TITLE
Tidy `fortran_project.correlate` and fix some minor bugs

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -23,9 +23,8 @@
 #
 
 import os
-import pathlib
 import toposort
-import itertools
+from itertools import chain
 from typing import List
 
 import ford.utils
@@ -190,7 +189,7 @@ class Project(object):
         ford.utils.external(self)
 
         # Match USE statements up with the module objects or links
-        for entity in itertools.chain(
+        for entity in chain(
             self.modules,
             self.procedures,
             self.programs,
@@ -233,15 +232,13 @@ class Project(object):
 
         deplist = {
             module: set(module.deplist)
-            for module in itertools.chain(self.modules, self.submodules)
+            for module in chain(self.modules, self.submodules)
         }
 
         # Get dependencies for programs and top-level procedures as well,
         # if dependency graphs are to be produced
         if self.settings["graph"]:
-            for entity in itertools.chain(
-                self.procedures, self.programs, self.blockdata
-            ):
+            for entity in chain(self.procedures, self.programs, self.blockdata):
                 entity.deplist = set(filter_modules(entity))
 
         ranklist = toposort.toposort_flatten(deplist)
@@ -403,7 +400,7 @@ def find_used_modules(
 
         # FIXME: We should capture whether or not the `use`d is
         # `intrinsic`, and modify the lookup appropriately
-        for candidate in itertools.chain(modules, external_modules):
+        for candidate in chain(modules, external_modules):
             if dependency_name == candidate.name.lower():
                 dependency[0] = candidate
                 break

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -365,7 +365,7 @@ class Project(object):
         return dir_list
 
 
-def id_mods(obj, modlist, intrinsic_mods={}, submodlist=[], extMods=[]):
+def id_mods(obj, modlist, intrinsic_mods, submodlist, extMods):
     """
     Match USE statements up with the right modules
     """
@@ -396,4 +396,4 @@ def id_mods(obj, modlist, intrinsic_mods={}, submodlist=[], extMods=[]):
         getattr(obj, "functions", []),
         getattr(obj, "subroutines", []),
     ):
-        id_mods(procedure, modlist, intrinsic_mods, extMods)
+        id_mods(procedure, modlist, intrinsic_mods, submodlist, extMods)

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -169,11 +169,15 @@ class Project(object):
 
         non_local_mods = INTRINSIC_MODS.copy()
         for item in self.settings["extra_mods"]:
+            if not item:
+                continue
             try:
                 name, url = item.split(":", 1)
             except ValueError:
-                print('Warning: could not parse extra modules "{}"'.format(item))
-                continue
+                raise ValueError(
+                    f"Could not parse 'extra_mods' item in project settings: '{item}'\n"
+                    "Expected something of the form 'module_name: http://link.to/module'"
+                )
             name = name.strip()
             url = url.strip().strip(r"\"'").strip()
             non_local_mods[name.lower()] = f'<a href="{url}">{name}</a>'

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -261,52 +261,28 @@ class Project(object):
         else:
             url = self.settings["project_url"]
 
+        # Mapping of various entity containers in code units to the
+        # corresponding container in the project
+        CONTAINERS = {
+            "functions": "procedures",
+            "subroutines": "procedures",
+            "interfaces": "procedures",
+            "absinterfaces": "absinterfaces",
+            "types": "types",
+            "modfunctions": "submodprocedures",
+            "modsubroutines": "submodprocedures",
+            "modprocedures": "submodprocedures",
+        }
+
+        # Gather all the entity containers from each code unit in each
+        # file into the corresponding project container
         for sfile in self.files:
-            for module in sfile.modules:
-                for function in module.functions:
-                    self.procedures.append(function)
-                for subroutine in module.subroutines:
-                    self.procedures.append(subroutine)
-                for interface in module.interfaces:
-                    self.procedures.append(interface)
-                for absint in module.absinterfaces:
-                    self.absinterfaces.append(absint)
-                for dtype in module.types:
-                    self.types.append(dtype)
-
-            for module in sfile.submodules:
-                for function in module.functions:
-                    self.procedures.append(function)
-                for subroutine in module.subroutines:
-                    self.procedures.append(subroutine)
-                for function in module.modfunctions:
-                    self.submodprocedures.append(function)
-                for subroutine in module.modsubroutines:
-                    self.submodprocedures.append(subroutine)
-                for modproc in module.modprocedures:
-                    self.submodprocedures.append(modproc)
-                for interface in module.interfaces:
-                    self.procedures.append(interface)
-                for absint in module.absinterfaces:
-                    self.absinterfaces.append(absint)
-                for dtype in module.types:
-                    self.types.append(dtype)
-
-            for program in sfile.programs:
-                for function in program.functions:
-                    self.procedures.append(function)
-                for subroutine in program.subroutines:
-                    self.procedures.append(subroutine)
-                for interface in program.interfaces:
-                    self.procedures.append(interface)
-                for absint in program.absinterfaces:
-                    self.absinterfaces.append(absint)
-                for dtype in program.types:
-                    self.types.append(dtype)
-
-            for block in sfile.blockdata:
-                for dtype in block.types:
-                    self.types.append(dtype)
+            for code_unit in chain(
+                sfile.modules, sfile.submodules, sfile.programs, sfile.blockdata
+            ):
+                for entity_kind, container in CONTAINERS.items():
+                    entities = getattr(code_unit, entity_kind, [])
+                    getattr(self, container).extend(entities)
 
         def sum_lines(*argv, **kwargs):
             """Wrapper for minimizing memory consumption"""

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -203,11 +203,7 @@ class Project(object):
 
         def get_deps(item):
             uselist = [m[0] for m in item.uses]
-            for procedure in itertools.chain(
-                getattr(item, "subroutines", []),
-                getattr(item, "functions", []),
-                getattr(item, "modprocedures", []),
-            ):
+            for procedure in item.routines:
                 uselist.extend(get_deps(procedure))
             return uselist
 
@@ -432,11 +428,7 @@ def find_used_modules(
                 break
 
     # Find the modules that this entity's procedures use
-    for procedure in itertools.chain(
-        getattr(entity, "modprocedures", []),
-        getattr(entity, "functions", []),
-        getattr(entity, "subroutines", []),
-    ):
+    for procedure in entity.routines:
         find_used_modules(
             procedure, modules, intrinsic_modules, submodules, external_modules
         )

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -215,18 +215,18 @@ class Project(object):
             deplist[mod] = set(mod.deplist)
 
         for mod in self.submodules:
-            if type(mod.ancestor_mod) is ford.sourceform.FortranModule:
+            if type(mod.ancestor_module) is ford.sourceform.FortranModule:
                 uselist = filter_modules(mod)
-                if mod.ancestor:
-                    if type(mod.ancestor) is ford.sourceform.FortranSubmodule:
-                        uselist.insert(0, mod.ancestor)
+                if mod.parent_submodule:
+                    if type(mod.parent_submodule) is ford.sourceform.FortranSubmodule:
+                        uselist.insert(0, mod.parent_submodule)
                     elif self.settings["warn"]:
                         print(
                             "Warning: could not identify parent SUBMODULE of SUBMODULE "
                             + mod.name
                         )
                 else:
-                    uselist.insert(0, mod.ancestor_mod)
+                    uselist.insert(0, mod.ancestor_module)
                 mod.deplist = uselist
                 deplist[mod] = set(uselist)
             elif self.settings["warn"]:
@@ -410,18 +410,18 @@ def find_used_modules(
                 continue
 
     # Find the ancestor of this submodule (if entity is one)
-    if getattr(entity, "ancestor", None):
-        ancestor_name = entity.ancestor.lower()
+    if getattr(entity, "parent_submodule", None):
+        parent_submodule_name = entity.parent_submodule.lower()
         for submod in submodules:
-            if ancestor_name == submod.name.lower():
-                entity.ancestor = submod
+            if parent_submodule_name == submod.name.lower():
+                entity.parent_submodule = submod
                 break
 
-    if hasattr(entity, "ancestor_mod"):
-        ancestor_mod_name = entity.ancestor_mod.lower()
+    if hasattr(entity, "ancestor_module"):
+        ancestor_module_name = entity.ancestor_module.lower()
         for mod in modules:
-            if ancestor_mod_name == mod.name.lower():
-                entity.ancestor_mod = mod
+            if ancestor_module_name == mod.name.lower():
+                entity.ancestor_module = mod
                 break
 
     # Find the modules that this entity's procedures use

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -292,9 +292,13 @@ class SubmodNode(ModNode):
         del self.used_by
         if not self.fromstr:
             if obj.parent_submodule:
-                self.parent_submodule = gd.get_node(obj.parent_submodule, FortranSubmodule)
+                self.parent_submodule = gd.get_node(
+                    obj.parent_submodule, FortranSubmodule
+                )
             else:
-                self.parent_submodule = gd.get_node(obj.parent_submodule_mod, FortranModule)
+                self.parent_submodule = gd.get_node(
+                    obj.parent_submodule_mod, FortranModule
+                )
             self.parent_submodule.children.add(self)
             self.efferent += 1
             self.parent_submodule.afferent += 1

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -291,13 +291,13 @@ class SubmodNode(ModNode):
         super().__init__(obj, gd)
         del self.used_by
         if not self.fromstr:
-            if obj.ancestor:
-                self.ancestor = gd.get_node(obj.ancestor, FortranSubmodule)
+            if obj.parent_submodule:
+                self.parent_submodule = gd.get_node(obj.parent_submodule, FortranSubmodule)
             else:
-                self.ancestor = gd.get_node(obj.ancestor_mod, FortranModule)
-            self.ancestor.children.add(self)
+                self.parent_submodule = gd.get_node(obj.parent_submodule_mod, FortranModule)
+            self.parent_submodule.children.add(self)
             self.efferent += 1
-            self.ancestor.afferent += 1
+            self.parent_submodule.afferent += 1
 
 
 class TypeNode(BaseNode):
@@ -305,7 +305,7 @@ class TypeNode(BaseNode):
 
     def __init__(self, obj, gd, hist=None):
         super().__init__(obj)
-        self.ancestor = None
+        self.parent_submodule = None
         self.children = set()
         self.comp_types = dict()
         self.comp_of = dict()
@@ -317,13 +317,13 @@ class TypeNode(BaseNode):
 
             if obj.extends:
                 if obj.extends in hist:
-                    self.ancestor = hist[obj.extends]
+                    self.parent_submodule = hist[obj.extends]
                 else:
-                    self.ancestor = gd.get_node(
+                    self.parent_submodule = gd.get_node(
                         obj.extends, FortranType, newdict(hist, obj, self)
                     )
-                self.ancestor.children.add(self)
-                self.ancestor.visible = getattr(obj.extends, "visible", True)
+                self.parent_submodule.children.add(self)
+                self.parent_submodule.visible = getattr(obj.extends, "visible", True)
 
             for var in obj.local_variables:
                 if (var.vartype == "type" or var.vartype == "class") and var.proto[
@@ -777,9 +777,9 @@ class ModuleGraph(FortranGraph):
                     hopNodes.add(nu)
                 hopEdges.append((n, nu, "dashed", colour))
             if hasattr(n, "ancestor"):
-                if n.ancestor not in self.added:
-                    hopNodes.add(n.ancestor)
-                hopEdges.append((n, n.ancestor, "solid", colour))
+                if n.parent_submodule not in self.added:
+                    hopNodes.add(n.parent_submodule)
+                hopEdges.append((n, n.parent_submodule, "solid", colour))
         # add nodes, edges and attributes to the graph if maximum number of
         # nodes is not exceeded
         if self.add_to_graph(hopNodes, hopEdges, nesting):
@@ -807,9 +807,9 @@ class UsesGraph(FortranGraph):
                     hopNodes.add(nu)
                 hopEdges.append((n, nu, "dashed", colour))
             if hasattr(n, "ancestor"):
-                if n.ancestor not in self.added:
-                    hopNodes.add(n.ancestor)
-                hopEdges.append((n, n.ancestor, "solid", colour))
+                if n.parent_submodule not in self.added:
+                    hopNodes.add(n.parent_submodule)
+                hopEdges.append((n, n.parent_submodule, "solid", colour))
         # add nodes and edges for this hop to the graph if maximum number of
         # nodes is not exceeded
         if not self.add_to_graph(hopNodes, hopEdges, nesting):
@@ -966,10 +966,10 @@ class TypeGraph(FortranGraph):
                 if c not in self.added:
                     hopNodes.add(c)
                 hopEdges.append((n, c, "dashed", colour, n.comp_types[c]))
-            if n.ancestor:
-                if n.ancestor not in self.added:
-                    hopNodes.add(n.ancestor)
-                hopEdges.append((n, n.ancestor, "solid", colour))
+            if n.parent_submodule:
+                if n.parent_submodule not in self.added:
+                    hopNodes.add(n.parent_submodule)
+                hopEdges.append((n, n.parent_submodule, "solid", colour))
         # add nodes, edges and attributes to the graph if maximum number of
         # nodes is not exceeded
         if self.add_to_graph(hopNodes, hopEdges, nesting):
@@ -996,10 +996,10 @@ class InheritsGraph(FortranGraph):
                 if c not in self.added:
                     hopNodes.add(c)
                 hopEdges.append((n, c, "dashed", colour, n.comp_types[c]))
-            if n.ancestor:
-                if n.ancestor not in self.added:
-                    hopNodes.add(n.ancestor)
-                hopEdges.append((n, n.ancestor, "solid", colour))
+            if n.parent_submodule:
+                if n.parent_submodule not in self.added:
+                    hopNodes.add(n.parent_submodule)
+                hopEdges.append((n, n.parent_submodule, "solid", colour))
         # add nodes and edges for this hop to the graph if maximum number of
         # nodes is not exceeded
         if not self.add_to_graph(hopNodes, hopEdges, nesting):

--- a/ford/output.py
+++ b/ford/output.py
@@ -280,7 +280,9 @@ class BasePage:
         try:
             return self.render(self.data, self.proj, self.obj)
         except Exception as e:
-            raise RuntimeError(f"Error rendering '{self.outfile.name}' for '{self.obj.name}' : {e}")
+            raise RuntimeError(
+                f"Error rendering '{self.outfile.name}' for '{self.obj.name}' : {e}"
+            )
 
     def writeout(self):
         with open(self.outfile, "wb") as out:

--- a/ford/output.py
+++ b/ford/output.py
@@ -277,7 +277,10 @@ class BasePage:
     @property
     def html(self):
         """Wrapper for only doing the rendering on request (drastically reduces memory)"""
-        return self.render(self.data, self.proj, self.obj)
+        try:
+            return self.render(self.data, self.proj, self.obj)
+        except Exception as e:
+            raise RuntimeError(f"Error rendering '{self.outfile.name}' for '{self.obj.name}' : {e}")
 
     def writeout(self):
         with open(self.outfile, "wb") as out:

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -575,8 +575,8 @@ class FortranBase(object):
 
     @property
     def routines(self):
-        """Iterator returning *both* functions and subroutines, in that order"""
-        for item in self.iterator("functions", "subroutines"):
+        """Iterator returning all procedures"""
+        for item in self.iterator("functions", "subroutines", "modprocedures"):
             yield item
 
     def iterator(self, *argv):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -987,7 +987,7 @@ class FortranContainer(FortranBase):
                     self.print_error(line, "Unexpected variable")
             elif self.USE_RE.match(line):
                 if hasattr(self, "uses"):
-                    self.uses.append(self.USE_RE.match(line).groups())
+                    self.uses.append(list(self.USE_RE.match(line).groups()))
                 else:
                     self.print_error(line, "Unexpected USE statement")
             else:

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -612,8 +612,12 @@ class FortranContainer(FortranBase):
     )
     MODULE_RE = re.compile(r"^module(?:\s+(\w+))?$", re.IGNORECASE)
     SUBMODULE_RE = re.compile(
-        r"^submodule\s*\(\s*(\w+)\s*(?::\s*(\w+))?\s*\)\s*(?:::|\s)\s*(\w+)$",
-        re.IGNORECASE,
+        r"""^submodule\s*
+        \(\s*(?P<ancestor_mod>\w+)\s*         # Non-optional ancestor module
+        (?::\s*(?P<parent_submod>\w+))?\s*\)  # Optional parent submodule
+        \s*(?P<name>\w+)                      # This submodule's name
+        $""",
+        re.IGNORECASE | re.VERBOSE,
     )
     PROGRAM_RE = re.compile(r"^program(?:\s+(\w+))?$", re.IGNORECASE)
     SUBROUTINE_RE = re.compile(

--- a/test/test_projects/test_external_project.py
+++ b/test/test_projects/test_external_project.py
@@ -2,7 +2,7 @@ import shutil
 import sys
 import os
 import pathlib
-import re
+import copy
 from urllib.parse import urlparse
 import json
 
@@ -57,39 +57,51 @@ REMOTE_MODULES_JSON = [
 ]
 
 
-@pytest.fixture
-def copy_project_files(tmp_path):
-    this_dir = pathlib.Path(__file__).parent
-    shutil.copytree(
-        this_dir / "../../test_data/external_project", tmp_path / "external_project"
-    )
-    return tmp_path / "external_project"
-
-
 class MockResponse:
     @staticmethod
     def read():
         return json.dumps(REMOTE_MODULES_JSON).encode("utf-8")
 
 
-def test_external_project(copy_project_files, monkeypatch, restore_macros):
-    """Check that we can build external projects and get the links correct
+@pytest.fixture(scope="module")
+def monkeymodule(request):
+    """pytest won't let us use function-scope fixtures in module-scope
+    fixtures, so we need to reimplement this with module scope"""
+    mpatch = pytest.MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
 
-    This is a rough-and-ready test that runs FORD via subprocess, and
-    so won't work unless FORD has been installed.
 
-    It also relies on access to the internet and an external URL out
-    of our control.
+@pytest.fixture(scope="module")
+def restore_macros_module():
+    """pytest won't let us use function-scope fixtures in module-scope
+    fixtures, so we need to reimplement this with module scope"""
+
+    old_macros = copy.copy(ford.utils._MACRO_DICT)
+    yield
+    ford.utils._MACRO_DICT = copy.copy(old_macros)
+
+
+@pytest.fixture(scope="module")
+def external_project(tmp_path_factory, monkeymodule, restore_macros_module):
+    """Generate the documentation for an "external" project and then
+    for a "top level" one that uses the first.
+
+    A remote external project is simulated through a mocked `urlopen`
+    which returns `REMOTE_MODULES_JSON`
 
     """
 
-    path = copy_project_files
+    this_dir = pathlib.Path(__file__).parent
+    path = tmp_path_factory.getbasetemp() / "external_project"
+    shutil.copytree(this_dir / "../../test_data/external_project", path)
+
     external_project = path / "external_project"
     top_level_project = path / "top_level_project"
 
     # Run FORD in the two projects
     # First project has "externalize: True" and will generate JSON dump
-    with monkeypatch.context() as m:
+    with monkeymodule.context() as m:
         os.chdir(external_project)
         m.setattr(sys, "argv", ["ford", "doc.md"])
         ford.run()
@@ -98,7 +110,7 @@ def test_external_project(copy_project_files, monkeypatch, restore_macros):
         return MockResponse()
 
     # Second project uses JSON from first to link to external modules
-    with monkeypatch.context() as m:
+    with monkeymodule.context() as m:
         os.chdir(top_level_project)
         m.setattr(sys, "argv", ["ford", "doc.md"])
         m.setattr(ford.utils, "urlopen", mock_open)
@@ -107,6 +119,14 @@ def test_external_project(copy_project_files, monkeypatch, restore_macros):
     # Make sure we're in a directory where relative paths won't
     # resolve correctly
     os.chdir("/")
+
+    return top_level_project, external_project
+
+
+def test_external_project(external_project):
+    """Check that we can build external projects and get the links correct"""
+
+    top_level_project, _ = external_project
 
     # Read generated HTML
     with open(top_level_project / "doc/program/top_level.html", "r") as f:
@@ -124,3 +144,22 @@ def test_external_project(copy_project_files, monkeypatch, restore_macros):
     assert "remote_module" in links
     remote_url = urlparse(links["remote_module"])
     assert remote_url.scheme == "https"
+
+
+def test_procedure_module_use_links_(external_project):
+    """Check that links to external modules used by functions are correct"""
+
+    top_level_project, _ = external_project
+
+    # Read generated HTML
+    with open(top_level_project / "doc/proc/abortcriteria_load.html", "r") as f:
+        procedure_html = BeautifulSoup(f.read(), features="html.parser")
+
+    # Find links to external modules
+    uses_box = procedure_html.find(string="Uses").parent.parent.parent
+    links = {tag.text: tag.a["href"] for tag in uses_box("li", class_=None)}
+
+    assert len(links) == 1
+    assert "external_module" in links
+    local_url = urlparse(links["external_module"])
+    assert pathlib.Path(local_url.path).is_file()

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -660,14 +660,14 @@ def test_submodule_ancestors(parse_fortran_file):
     mod_c = fortran_file.submodules[1]
     mod_d = fortran_file.submodules[2]
 
-    assert mod_b.ancestor is None
-    assert mod_b.ancestor_mod == "mod_a"
+    assert mod_b.parent_submodule is None
+    assert mod_b.ancestor_module == "mod_a"
 
-    assert mod_c.ancestor is None
-    assert mod_c.ancestor_mod == "mod_a"
+    assert mod_c.parent_submodule is None
+    assert mod_c.ancestor_module == "mod_a"
 
-    assert mod_d.ancestor == "mod_c"
-    assert mod_d.ancestor_mod == "mod_a"
+    assert mod_d.parent_submodule == "mod_c"
+    assert mod_d.ancestor_module == "mod_a"
 
 
 @dataclass

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1102,3 +1102,72 @@ def test_bad_parses(snippet, expected_error, expected_name, parse_fortran_file):
 
     assert expected_error in e.value.args[0]
     assert expected_name in e.value.args[0]
+
+
+def test_routine_iterator(parse_fortran_file):
+    data = """\
+    module foo
+      interface
+        module subroutine modsub1()
+        end subroutine modsub1
+        module subroutine modsub2()
+        end subroutine modsub2
+        module integer function modfunc1()
+        end function modfunc1
+        module integer function modfunc2()
+        end function modfunc2
+      end interface
+    contains
+      subroutine sub1()
+      end subroutine sub1
+      subroutine sub2()
+      end subroutine sub2
+      integer function func1()
+      end function func1
+      integer function func2()
+      end function func2
+    end module foo
+
+    submodule (foo) bar
+    contains
+      module subroutine modsub1
+      end subroutine modsub1
+      module subroutine modsub2
+      end subroutine modsub2
+      module procedure modfunc1
+      end procedure modfunc1
+      module procedure modfunc2
+      end procedure modfunc2
+
+      subroutine sub3()
+      end subroutine sub3
+      subroutine sub4()
+      end subroutine sub4
+      integer function func3()
+      end function func3
+      integer function func4()
+      end function func4
+    end submodule bar
+    """
+
+    fortran_file = parse_fortran_file(data)
+
+    module = fortran_file.modules[0]
+    assert sorted([proc.name for proc in module.routines]) == [
+        "func1",
+        "func2",
+        "sub1",
+        "sub2",
+    ]
+
+    submodule = fortran_file.submodules[0]
+    assert sorted([proc.name for proc in submodule.routines]) == [
+        "func3",
+        "func4",
+        "modfunc1",
+        "modfunc2",
+        "modsub1",
+        "modsub2",
+        "sub3",
+        "sub4",
+    ]

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -637,6 +637,39 @@ def test_module_procedure_case(parse_fortran_file):
     assert module.interfaces[3].procedure.module
 
 
+def test_submodule_ancestors(parse_fortran_file):
+    """Check that submodule ancestors and parents are correctly identified"""
+
+    data = """\
+    module mod_a
+    end module mod_a
+
+    submodule (mod_a) mod_b
+    end submodule mod_b
+
+    submodule (mod_a) mod_c
+    end submodule mod_c
+
+    submodule (mod_a:mod_c) mod_d
+    end submodule mod_d
+    """
+
+    fortran_file = parse_fortran_file(data)
+
+    mod_b = fortran_file.submodules[0]
+    mod_c = fortran_file.submodules[1]
+    mod_d = fortran_file.submodules[2]
+
+    assert mod_b.ancestor is None
+    assert mod_b.ancestor_mod == "mod_a"
+
+    assert mod_c.ancestor is None
+    assert mod_c.ancestor_mod == "mod_a"
+
+    assert mod_d.ancestor == "mod_c"
+    assert mod_d.ancestor_mod == "mod_a"
+
+
 @dataclass
 class ParsedType:
     vartype: str

--- a/test_data/external_project/external_project/src/external.f90
+++ b/test_data/external_project/external_project/src/external.f90
@@ -17,22 +17,23 @@ module external_module
 
 
   abstract interface
-
     !> Loading additional parameters for solver specific abort criteria.
-    subroutine load_aborts(me, handle)
+    subroutine load_aborts(self, handle)
       import solverAborts_type
-
       !> The solver specific type to hold additional abort parameters.
-      class(solverAborts_type), intent(inout) :: me
-
+      class(solverAborts_type), intent(inout) :: self
       !> Handle to configuration to load parameters from.
-      integer, intent(in) :: conf
-
+      integer, intent(in) :: handle
     end subroutine load_aborts
-
   end interface
 
 contains
   subroutine external_sub
   end subroutine external_sub
+
+  !> Fraction to abort at
+  real function abort_fraction()
+    abort_fraction = 0.15
+  end function abort_fraction
+  
 end module external_module

--- a/test_data/external_project/top_level_project/src/top_level.f90
+++ b/test_data/external_project/top_level_project/src/top_level.f90
@@ -14,6 +14,7 @@ module myAbort
 contains
 
   subroutine abortCriteria_load(me, conf)
+    use external_module, only: abort_fraction
     ! -------------------------------------------------------------------- !
     !> Object to hold the solver specific configuration parameters.
     class(vel_abortCriteria_type), intent(inout) :: me
@@ -21,7 +22,7 @@ contains
     !> Handle to the configuration.
     integer, intent(in) :: conf
 
-    me%velmax = real(conf)*0.15
+    me%velmax = real(conf)*abort_fraction()
 
   end subroutine mus_abortCriteria_load
 


### PR DESCRIPTION
Bugs fixed:

- linking to external modules used by procedures didn't work
- submodule statement matching included extraneous `::`
- invalid `extra_mods` in settings would only print warning, now hard error

Lots of code duplication removed, and a bunch of tests added