### PR TITLE
read project file with utf8 encoding

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -246,7 +246,7 @@ def get_command_line_arguments() -> argparse.Namespace:
     parser.add_argument(
         "project_file",
         help="file containing the description and settings for the project",
-        type=argparse.FileType("r"),
+        type=argparse.FileType("r", encoding='UTF-8'),
     )
     parser.add_argument(
         "-d",


### PR DESCRIPTION
When I built the documentations of my project, I found garbled texts which are non-ascii characters in the produced index.html page. Then I modified the encoding of opening the project file in FORD, and got the correct texts.
I guess this happens because the default encoding of my OS is gbk, and FORD uses this setting since its encoding is not specified manually.
I think it is OK to force UTF-8 encoding for project file and this change will help to produce consistent output pages.