### PR TITLE
Fix doc summaries for types; other minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ following command:
     spack install py-ford
 
 ## Documentation
-More complete documentation can be found in the [docs](https://forddocs.readthedocs.io/en/).
+More complete documentation can be found in the [docs](https://forddocs.readthedocs.io).
 
 ## License
 This program is free software: you can redistribute it and/or modify

--- a/docs/user_guide/getting_started.rst
+++ b/docs/user_guide/getting_started.rst
@@ -81,7 +81,7 @@ And now we can view the documentation in our browser at
 looks like:
 
 .. image:: say_hello_example.png
-   :alt: Example of FORD generated documenation for the "hello" program
+   :alt: Example of FORD generated documentation for the "hello" program
 
 .. rubric:: Footnotes
 

--- a/example/src/ford_example_type.f90
+++ b/example/src/ford_example_type.f90
@@ -17,15 +17,26 @@ module ford_example_type_mod
     !! Internal counter
     character(len=:), allocatable, public :: name
     !! Name of this instance
+    !!
+    !! More documentation
   contains
     procedure :: say_hello => example_type_say
     !! This will document the type-bound procedure *binding*, rather
     !! than the procedure itself. The specific procedure docs will be
-    !! rendered on the `example_type` page.
+    !! rendered on the [[example_type]] page.
+    !!
+    !! This binding has more documentation beyond the summary
+    final :: example_type_finalise
+    !! This is the finaliser, called when the instance is destroyed.
+    !!
+    !! This finaliser has more documentation beyond the summary
   end type example_type
 
   interface example_type
     !! This is a constructor for our type
+    !!
+    !! This constructor has more documentation that won't appear in
+    !! the procedure list, but should appear in the type page
     module procedure make_new_type
   end interface example_type
 
@@ -37,13 +48,25 @@ contains
     !! This subroutine has more documentation that won't appear in the
     !! summary in the procedure list, but should appear in the type
     !! page.
-    class(example_type), intent(in) :: self
+    class(example_type), intent(inout) :: self
     write(*, '(a, " has said hello ", i0, " times.")') self%name, self%counter
     self%counter = self%counter + 1
   end subroutine example_type_say
 
   type(example_type) function make_new_type() result(self)
-    make_new_type%name = "some-default-name"
+    !! This is the documentation for the specific constructor
+    !!
+    !! More documentation
+    self%name = "some-default-name"
   end function make_new_type
+
+  subroutine example_type_finalise(self)
+    !! Cleans up an [[example_type(type)]] instance
+    !!
+    !! More documentation
+    type(example_type), intent(inout) :: self
+    call self%say_hello()
+    write(*, '(a, " says goodbye")') self%name
+  end subroutine example_type_finalise
 
 end module ford_example_type_mod

--- a/example/src/ford_test_module.fpp
+++ b/example/src/ford_test_module.fpp
@@ -25,6 +25,8 @@ contains
 #endif
 
   subroutine apply_check(f)
+    !! deprecated: true
+    !!
     !! Takes a function and immediately calls it
     procedure(check) :: f
     !! Some function to call

--- a/ford/output.py
+++ b/ford/output.py
@@ -260,7 +260,7 @@ class Documentation(object):
         for p in chain(self.docs, self.lists, self.pagetree, [self.index, self.search]):
             p.writeout()
 
-        print(f"\nBrowse the generated documenation: file://{out_dir}/index.html")
+        print(f"\nBrowse the generated documentation: file://{out_dir}/index.html")
 
 
 class BasePage:

--- a/ford/reader.py
+++ b/ford/reader.py
@@ -241,7 +241,7 @@ class FortranReader(object):
             if len(line.strip()) > 0 and line.strip()[0] == "#":
                 continue
 
-            # Capture any preceding documenation comments
+            # Capture any preceding documentation comments
             match = _match_docmark(self.predoc_re, line, in_quote)
             if match:
                 # Switch to predoc: following comment lines are predoc until the end of the block

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -580,7 +580,7 @@ class FortranContainer(FortranBase):
         r"^type(?:\s+|\s*(,.*)?::\s*)((?!(?:is\s*\())\w+)\s*(\([^()]*\))?\s*$",
         re.IGNORECASE,
     )
-    INTERFACE_RE = re.compile(r"^(abstract\s+)?interface(?:\s+(\S.+))?$", re.IGNORECASE)
+    INTERFACE_RE = re.compile(r"^(abstract\s+)?interface(?:\s+(.+))?$", re.IGNORECASE)
     # ~ ABS_INTERFACE_RE = re.compile(r"^abstract\s+interface(?:\s+(\S.+))?$",re.IGNORECASE)
     BOUNDPROC_RE = re.compile(
         r"^(generic|procedure)\s*(\([^()]*\))?\s*(.*)\s*::\s*(\w.*)", re.IGNORECASE

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -29,6 +29,7 @@ import os.path
 import copy
 import textwrap
 from typing import List, Tuple
+from itertools import chain
 
 # Python 2 or 3:
 if sys.version_info[0] > 2:
@@ -195,7 +196,14 @@ class FortranBase(object):
         if loc:
             return outstr.format(self.base_url, loc, quote(self.ident))
         if isinstance(
-            self, (FortranBoundProcedure, FortranCommon, FortranVariable, FortranEnum)
+            self,
+            (
+                FortranBoundProcedure,
+                FortranCommon,
+                FortranVariable,
+                FortranEnum,
+                FortranFinalProc,
+            ),
         ):
             parent_url = self.parent.get_url()
             if parent_url:
@@ -390,34 +398,9 @@ class FortranBase(object):
             self._ensure_meta_key_set("proc_internals", ford.utils.str_to_bool)
 
         # Create Markdown
-        for item in self.iterator(
-            "variables",
-            "modules",
-            "submodules",
-            "common",
-            "subroutines",
-            "modprocedures",
-            "functions",
-            "interfaces",
-            "absinterfaces",
-            "types",
-            "programs",
-            "blockdata",
-            "boundprocs",
-            "finalprocs",
-            "args",
-            "enums",
-        ):
+        for item in self.children:
             if isinstance(item, FortranBase):
                 item.markdown(md, project)
-        if hasattr(self, "retvar"):
-            if self.retvar:
-                if isinstance(self.retvar, FortranBase):
-                    self.retvar.markdown(md, project)
-        if hasattr(self, "procedure"):
-            if isinstance(self.procedure, FortranBase):
-                self.procedure.markdown(md, project)
-        return
 
     def sort_components(self):
         """Sorts components using the method specified in the object
@@ -493,39 +476,14 @@ class FortranBase(object):
             self.meta["summary"] = ford.utils.sub_links(self.meta["summary"], project)
 
         # Create links in the project
-        for item in self.iterator(
-            "variables",
-            "types",
-            "enums",
-            "modules",
-            "submodules",
-            "subroutines",
-            "functions",
-            "interfaces",
-            "absinterfaces",
-            "programs",
-            "boundprocs",
-            "args",
-            "bindings",
-        ):
+        for item in self.children:
             if isinstance(item, FortranBase) and hasattr(item, "doc"):
                 item.make_links(project)
-        if hasattr(self, "retvar"):
-            if self.retvar:
-                if isinstance(self.retvar, FortranBase):
-                    self.retvar.make_links(project)
-        if hasattr(self, "procedure"):
-            if isinstance(self.procedure, FortranBase):
-                self.procedure.make_links(project)
-
-        # if hasattr(self,'finalprocs'): recurse_list.extend(self.finalprocs)
-        # if hasattr(self,'constructor') and self.constructor: recurse_list.append(self.constructor)
 
     @property
     def routines(self):
         """Iterator returning all procedures"""
-        for item in self.iterator("functions", "subroutines", "modprocedures"):
-            yield item
+        return self.iterator("functions", "subroutines", "modprocedures")
 
     def iterator(self, *argv):
         """Iterator returning any list of elements via attribute lookup in ``self``
@@ -535,6 +493,35 @@ class FortranBase(object):
             if hasattr(self, arg):
                 for item in getattr(self, arg):
                     yield item
+
+    @property
+    def children(self):
+        """Iterator over all child entities"""
+
+        non_list_children = ["constructor", "procedure", "retvar"]
+
+        return chain(
+            self.iterator(
+                "absinterfaces",
+                "args",
+                "blockdata",
+                "bindings",
+                "boundprocs",
+                "common",
+                "enums",
+                "finalprocs",
+                "functions",
+                "interfaces",
+                "modprocedures",
+                "modules",
+                "programs",
+                "submodules",
+                "subroutines",
+                "types",
+                "variables",
+            ),
+            filter(None, (getattr(self, item, None) for item in non_list_children)),
+        )
 
 
 class FortranContainer(FortranBase):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -257,9 +257,13 @@ class FortranBase(object):
         """
         return self.ident < other.ident
 
-    def _ensure_meta_key_set(self, key: str, transform=None):
-        """Ensure that 'key' is set in self.meta, after applying an optional transform"""
-        value = self.meta.get(key, self.settings[key])
+    def _ensure_meta_key_set(self, key: str, transform=None, default=None):
+        """Ensure that ``key`` is set in ``self.meta``, after applying
+        an optional ``transform``.
+
+        Use ``default`` if ``key`` is not in ``self.settings``.
+        """
+        value = self.meta.get(key, self.settings.get(key, default))
         if transform:
             self.meta[key] = transform(value)
         else:
@@ -364,6 +368,7 @@ class FortranBase(object):
         self._ensure_meta_key_set("graph", ford.utils.str_to_bool)
         self._ensure_meta_key_set("graph_maxdepth")
         self._ensure_meta_key_set("graph_maxnodes")
+        self._ensure_meta_key_set("deprecated", ford.utils.str_to_bool, False)
 
         if self.obj in ["proc", "type", "program"]:
             self._ensure_meta_key_set("source", ford.utils.str_to_bool)

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -238,18 +238,11 @@ class FortranBase(object):
         return f"{self.obj}-{quote(self.ident)}"
 
     def __str__(self):
-        outstr = "<a href='{0}'>{1}</a>"
         url = self.get_url()
         if url and getattr(self, "visible", True):
-            if self.name:
-                name = self.name
-            else:
-                name = "<em>unnamed</em>"
-            return outstr.format(url, name)
-        elif self.name:
-            return self.name
-        else:
-            return ""
+            name = self.name or "<em>unnamed</em>"
+            return f"<a href='{url}'>{name}</a>"
+        return self.name or ""
 
     def __lt__(self, other):
         """

--- a/ford/templates/block_page.html
+++ b/ford/templates/block_page.html
@@ -4,10 +4,8 @@
   {% import 'macros.html' as macros %}
   <div class="row">
     <h1>{{ blockdat.name }} 
-    <small>Block Data</small>
-    {% if blockdat.meta['deprecated'] and blockdat.meta['deprecated'].lower() == 'true' %}
-    <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      <small>Block Data</small>
+      {{ macros.deprecated(blockdat) }}
     </h1>
     {{ macros.info_bar(blockdat, incl_src, project_url, blockdat.lines_description(project.block_lines)) }}
   </div>

--- a/ford/templates/file_page.html
+++ b/ford/templates/file_page.html
@@ -4,10 +4,8 @@
   {% import 'macros.html' as macros %}
   <div class="row">
     <h1>{{ src.name }}
-    <small>Source File</small>
-    {% if src.meta['deprecated'] and src.meta['deprecated'].lower() == 'true' %}
-   <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      <small>Source File</small>
+      {{ macros.deprecated(src) }}
     </h1>
     {{ macros.info_bar(src, incl_src, project_url, src.lines_description(project.file_lines)) }}
   </div>

--- a/ford/templates/genint_page.html
+++ b/ford/templates/genint_page.html
@@ -4,10 +4,8 @@
   {% import 'macros.html' as macros %}
   <div class="row">
     <h1>{{ interface.name }}
-   <small>Interface</small>
-    {% if interface.meta['deprecated'] and interface.meta['deprecated'].lower() == 'true' %}
-    <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      <small>Interface</small>
+      {{ macros.deprecated(interface) }}
     </h1>
     {{ macros.info_bar(interface, incl_src, project_url, interface.lines_description(project.proc_lines,project.proc_lines,'proc')) }}
   </div>

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -240,7 +240,16 @@
   {%- endif -%}
 {%- endmacro -%}
 
-{% macro proc_summary(proc,title=True,small=False,proto=False) %}
+{%- macro docstring(entity, full_docstring=True) -%}
+  {# Display either the full docstring or just the summary #}
+  {%- if full_docstring or not entity.visible -%}
+    {{ entity.doc }}
+  {%- else -%}
+    {{ entity.meta["summary"] }}
+  {%- endif -%}
+{%- endmacro -%}
+
+{% macro proc_summary(proc, title=True, small=False, proto=False, full_docstring=False) %}
   {# Render the summary of a procedure, to be used in lists of procedures, for example #}
   {% if title %}
     {{ header(3, small) }}
@@ -251,7 +260,7 @@
   {% if proc.parent and proc.visible %}
     {{ meta_list(proc.meta) }}
   {% endif %}
-  {{ proc.meta['summary'] }}
+  {{ docstring(proc, full_docstring) }}
 
   {{ header(4, small) }}Arguments{{ close_header(4, small) }}
   {% if proc.args %}
@@ -264,7 +273,7 @@
     Return Value
     <small>{{ proc.retvar.full_declaration }}</small>
     {{ close_header(4, small) }}
-    {{ proc.retvar.meta['summary'] }}
+    {{ docstring(proc.retvar, full_docstring) }}
   {% endif %}
 {% endmacro %}
 
@@ -349,34 +358,39 @@
 {% endmacro %}
 
 
-{% macro interface(intr) %}
+{% macro interface(intr, full_docstring=True) %}
   <div class="panel panel-default">
-    <div class="panel-heading codesum"><span class="anchor" id="{{ intr.anchor }}"></span><h3>{% if intr.parobj == 'module' and intr.generic %}{{ intr.permission }} {% endif %}interface {% if intr.generic %}{% if intr.visible %}{{ intr }}{% else %}{{ intr.name }}{% endif %}{% endif %}
+    <div class="panel-heading codesum">
+      <span class="anchor" id="{{ intr.anchor }}"></span>
+      <h3>{% if intr.parobj == 'module' and intr.generic %}{{ intr.permission }}{% endif %}
+        interface
+        {%- if intr.generic %} {{ intr }} {% endif -%}
         {{ deprecated(intr) }}
-    </h3></div>
+      </h3>
+    </div>
     {% if intr.doc or (meta_list(intr.meta)|trim and not intr.visible) %}
       <div class="panel-body">
         {% if not intr.visible %}
           {{ meta_list(intr.meta) }}
         {% endif %}
-        {{ intr.meta['summary'] }}
+        {{ docstring(intr, full_docstring) }}
       </div>
     {% endif %}
     <ul class="list-group">
       {% if intr.generic %}
-        {% for proc in intr.functions + intr.subroutines %}
+        {% for proc in intr.routines %}
           <li class="list-group-item">
-            {{ proc_summary(proc) }}
+            {{ proc_summary(proc, full_docstring=full_docstring) }}
           </li>
         {% endfor %}
         {% for proc in intr.modprocs %}
           <li class="list-group-item">
-            {{ proc_summary(proc.procedure) }}
+            {{ proc_summary(proc.procedure, full_docstring=full_docstring) }}
           </li>
         {% endfor %}
       {% else %}
         <li class="list-group-item">
-          {{ proc_summary(intr.procedure) }}
+          {{ proc_summary(intr.procedure, full_docstring=full_docstring) }}
         </li>
       {% endif %}
     </ul>
@@ -416,81 +430,130 @@
 
 {% macro final(proc) %}
   <div class="panel panel-default">
-    <div class="panel-heading codesum"><span class="anchor" id="{{ proc.anchor }}"></span><h3>final :: <strong>{{ proc.name }}</strong> {{ deprecated(proc) }}
-    </h3></div>
-        <div class="panel-body">
-          {{ meta_list(proc.meta) }}
-          {{ proc.doc }}
-        </div>
-        <ul class="list-group">
-          <li class="list-group-item">
-            {{ proc_summary(proc.procedure,title=True) }}
-          </li>
-        </ul>
+    <div class="panel-heading codesum">
+      <span class="anchor" id="{{ proc.anchor }}"></span>
+      <h3>final :: <strong>{{ proc.name }}</strong> {{ deprecated(proc) }}</h3>
+    </div>
+    <div class="panel-body">
+      {{ meta_list(proc.meta) }}
+      {{ proc.doc }}
+    </div>
+    <ul class="list-group">
+      <li class="list-group-item">
+        {{ proc_summary(proc.procedure, title=True, full_docstring=True) }}
+      </li>
+    </ul>
   </div>
 {% endmacro %}
 
+{% macro display_permission(item) %}
+  {% if item.parobj == "module" or (item.parobj == "interface" and item.parent.parobj == "module") %}
+    {{ item.permission }}
+  {% endif %}
+{% endmacro %}
 
 {% macro type_summary(dtype) %}
   <div class="panel panel-default">
-    <div class="panel-heading codesum"><span class="anchor" id="{{ dtype.anchor }}"></span><h3>type{% if dtype.parobj == 'module' %}, {{ dtype.permission }}{% endif %}{% if dtype.sequence %}, sequence {% endif %}{% for attrib in dtype.attributes -%}, {{ attrib }}{%- endfor %}{% if dtype.extends %}, extends({{ dtype.extends }}){% endif %} :: {% if dtype.visible %}{{ dtype }}{% else %}{{ dtype.name }}{% endif %}
+    <div class="panel-heading codesum">
+      <span class="anchor" id="{{ dtype.anchor }}"></span>
+      <h3>
+        type
+        {%- if dtype.parobj == 'module' %}, {{ dtype.permission }}{% endif -%}
+        {%- if dtype.sequence %}, sequence {% endif -%}
+        {{ dtype.attribs | join(", ") }}
+        {%- if dtype.extends %}, extends({{ dtype.extends }}){% endif -%}&nbsp;::&nbsp;
+        {{ dtype }}
         {{ deprecated(dtype) }}
-    </h3></div>
+      </h3>
+    </div>
     <div class="panel-body">
-      {% if dtype.doc or (meta_list(dtype.meta)|trim and not dtype.visible) %}
-        {% if not dtype.visible %}
-          {{ meta_list(dtype.meta) }}
-        {% endif %}
-        {{ dtype.meta['summary'] }}
+      {% if not dtype.visible %}
+        {{ meta_list(dtype.meta) }}
       {% endif %}
+      {{ dtype.meta['summary'] }}
+
       {% if dtype.variables %}
         <h4>Components</h4>
         {{ variable_list(dtype.variables, permission=True, summary=True) }}
       {% endif %}
+
       {% if dtype.constructor %}
         <h4>Constructor</h4>
         {% if dtype.constructor.obj == 'interface' %}
-          {{ dtype.constructor.meta['summary'] }}
+          {{ docstring(dtype.constructor, full_docstring=False) }}
         {% endif %}
         <table class="table table-striped varlist">
           <tbody>
             {% if dtype.constructor.obj == 'proc' %}
-              <tr><td>{{ proc_line(dtype.constructor) }}</td><td>{{ dtype.constructor.meta['summary'] }}</td></tr>
+              <tr>
+                <td>{{ proc_line(dtype.constructor) }}</td>
+                <td>{{ docstring(dtype.constructor, full_docstring=False) }}</td>
+              </tr>
             {% elif dtype.constructor.obj == 'interface' %}
-              {% for proc in dtype.constructor.functions + dtype.constructor.subroutines %}
-                <tr><td>{% if proc.parobj == 'module' or (proc.parobj == 'interface' and proc.parent.parobj == 'module') %}{{ proc.permission }} {% endif %}{% for attrib in proc.attribs -%}{{ attrib }}{% if not loop.last -%}, {%- endif %}{%- endfor %} {{ proc.proctype|lower }} <strong>{% if proc.visible %}{{ proc }}{% else %}{{ proc.name }}{% endif %}</strong>({% for arg in proc.args -%}{{ arg }}{% if not loop.last -%}, {% endif %}{%- endfor %}){% if proc.bindC -%}, bind({{ proc.bindC }}){% endif %}</td><td>{{ proc.meta['summary'] }}</td></tr>
-              {% endfor %}
-              {% for mproc in dtype.constructor.modprocs %}
-                {% set proc = mproc.procedure %}
-                <tr><td>{% if proc.parobj == 'module' or (proc.parobj == 'interface' and proc.parent.parobj == 'module') %}{{ proc.permission }} {% endif %}{% for attrib in proc.attribs -%}{{ attrib }}{% if not loop.last -%}, {%- endif %}{%- endfor %} {{ proc.proctype|lower }} <strong>{% if proc.visible %}{{ proc }}{% else %}{{ proc.name }}{% endif %}</strong>({% for arg in proc.args -%}{{ arg }}{% if not loop.last -%}, {% endif %}{%- endfor %}){% if proc.bindC -%}, bind({{ proc.bindC }}){% endif %}</td><td>{{ proc.meta['summary'] }}</td></tr>
+              {% for proc in dtype.constructor.routines|list + dtype.constructor.modprocs|map(attribute="procedure")|list %}
+                <tr>
+                  <td>
+                    {{ display_permission(proc) }}
+                    {{ proc.attribs | join(", ") }}
+                    {{ proc.proctype|lower }}
+                    <strong>{{ proc }}</strong>
+                    ({{ proc.args | join(", ") }})
+                    {% if proc.bindC -%}, bind({{ proc.bindC }}){% endif %}
+                  </td>
+                  <td>{{ docstring(proc, full_docstring=False) }}</td>
+                </tr>
               {% endfor %}
             {% endif %}
           </tbody>
         </table>
       {% endif %}
+
       {% if dtype.finalprocs %}
         <h4>Finalizations Procedures</h4>
         <table class="table table-striped varlist">
           <tbody>
             {% for fin in dtype.finalprocs %}
-              <tr><td>final :: <strong>{{ fin.name }}</strong></h3></td><td>{{ fin.meta['summary'] }}</td></tr>
+              <tr>
+                <td>final :: <strong>{{ fin.name }}</strong></td>
+                <td>{{ fin.meta['summary'] }}</td>
+              </tr>
             {% endfor %}
-</tbody>
-</table>
-{% endif %}
-{% if dtype.boundprocs %}
-  <h4>Type-Bound Procedures</h4>
-  <table class="table table-striped varlist">
-    <tbody>
-      {% for tb in dtype.boundprocs %}
-        <tr><td>{% if tb.generic -%}generic,{% else %}procedure{% if tb.proto -%}({% if not tb.protomatch -%}{{ tb.proto }}{% else %}{{ tb.proto.name }}{%- endif %}){%- endif %},{%- endif %} {{ tb.permission }}{% if tb.attribs -%}, {% for attrib in tb.attribs -%}{{ attrib }}{% if not loop.last -%}, {% endif %}{%- endfor %}{%- endif %} :: <strong>{{ tb }}</strong> {% if tb.generic or (tb.name != tb.bindings[0].name and tb.name != tb.bindings[0]) %} => {% for bind in tb.bindings -%}{{ bind.name }}{% if not loop.last -%}, {% endif %}{%- endfor %}{% endif %} {% if tb.binding|length == 1 %}<small>{{ tb.bindings[0].proctype }}</small>{% endif %}</td>
-          <td>{{ tb.meta['summary'] }}</td></tr>
-        {% endfor %}
-    </tbody>
-  </table>
-{% endif %}
-</div>
-</div>
+          </tbody>
+        </table>
+      {% endif %}
+
+      {% if dtype.boundprocs %}
+        <h4>Type-Bound Procedures</h4>
+        <table class="table table-striped varlist">
+          <tbody>
+            {% for tb in dtype.boundprocs %}
+              <tr>
+                <td>
+                  {% if tb.generic -%}
+                    generic,
+                  {% else %}
+                    procedure
+                    {% if tb.proto -%}
+                      ({% if not tb.protomatch -%}{{ tb.proto }}{% else %}{{ tb.proto.name }}{%- endif %})
+                    {%- endif %}
+                    ,
+                  {%- endif %}
+                  {{ tb.permission }}
+                  {% if tb.attribs -%}, {{ tb.attribs|join(", ") }}{%- endif %}
+                  :: <strong>{{ tb }}</strong>
+                  {% if tb.generic or (tb.name != tb.bindings[0].name and tb.name != tb.bindings[0]) %} =>
+                    {{ tb.bindings|join(", ") }}
+                  {% endif %}
+                  {% if tb.bindings|length == 1 %}<small>{{ tb.bindings[0].proctype }}</small>{% endif %}
+                </td>
+                <td>{{ tb.meta['summary'] }}</td>
+              </tr>
+              {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    </div>
+  </div>
 {% endmacro %}
 
 {% macro common_block(com) %}

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -151,6 +151,13 @@
   {%- if condition -%},{% endif %}
 {% endmacro %}
 
+{% macro deprecated(entity) %}
+  {# Add 'Deprecated' warning #}
+  {%- if entity.meta['deprecated'] -%}
+    <span class="label label-danger depwarn">Deprecated</span>
+  {%- endif -%}
+{% endmacro %}
+
 {% macro variable_list(variables, intent=False, permission=False, summary=False, id=True) %}
   <table class="table table-striped varlist">
     <thead>
@@ -294,9 +301,7 @@
 {% macro bound_info(tb) %}
   <div class="panel panel-default">
     <div class="panel-heading codesum"><span class="anchor" id="{{ tb.anchor }}"></span><h3>{% if tb.generic -%}generic,{% else %}procedure{% if tb.proto -%}({% if not tb.protomatch or tb.proto.visible -%}{{ tb.proto }}{% else %}{{ tb.proto.name }}{%- endif %}){%- endif %},{%- endif %} {{ tb.permission }}{% if tb.deferred -%}, deferred{%- endif %}{% if tb.attribs -%}, {% for attrib in tb.attribs -%}{{ attrib }}{% if not loop.last -%}, {% endif %}{%- endfor %}{%- endif %} :: <strong>{{ tb.name }}</strong> {% if tb.generic or (tb.name != tb.bindings[0].name and tb.name != tb.bindings[0]) %} => {% for bind in tb.bindings -%}{% if not bind.parent or bind.visible %}{{ bind }}{% else %}{{ bind.name }}{% endif %}{% if not loop.last -%}, {% endif %}{%- endfor %}{% endif %} {% if tb.binding|length == 1 %}<small>{{ tb.bindings[0].proctype }}</small>{% endif %}
-        {% if tb.meta['deprecated'] and tb.meta['deprecated'].lower() == 'true' %}
-          <span class="label label-danger depwarn">Deprecated</span>
-        {% endif %}
+        {{ deprecated(tb) }}
     </h3></div>
     {% if tb.doc or meta_list(tb.meta)|trim|length is more_than_one %}
       <div class="panel-body">
@@ -325,12 +330,7 @@
             {% endif %}
           {% else %}
             {% if bind.obj == 'interface' %}
-              <h3>interface
-                {% if bind.meta['deprecated'] and bind.meta['deprecated'].lower() == 'true' %}
-                  <span class="label label-danger depwarn">Deprecated</span>
-                {% endif %}
-              </h3>
-
+              <h3>interface {{ deprecated(bind) }}</h3>
               {% if bind.doc or (meta_list(bind.meta)|trim and not bind.visible) %}
                 {% if not bind.visible %}
                   {{ meta_list(bind.meta) }}
@@ -352,9 +352,7 @@
 {% macro interface(intr) %}
   <div class="panel panel-default">
     <div class="panel-heading codesum"><span class="anchor" id="{{ intr.anchor }}"></span><h3>{% if intr.parobj == 'module' and intr.generic %}{{ intr.permission }} {% endif %}interface {% if intr.generic %}{% if intr.visible %}{{ intr }}{% else %}{{ intr.name }}{% endif %}{% endif %}
-        {% if intr.meta['deprecated'] and intr.meta['deprecated'].lower() == 'true' %}
-          <span class="label label-danger depwarn">Deprecated</span>
-        {% endif %}
+        {{ deprecated(intr) }}
     </h3></div>
     {% if intr.doc or (meta_list(intr.meta)|trim and not intr.visible) %}
       <div class="panel-body">
@@ -388,9 +386,7 @@
 {% macro absinterface(intr) %}
   <div class="panel panel-default">
     <div class="panel-heading codesum"><span class="anchor" id="{{ intr.anchor }}"></span><h3>abstract interface
-        {% if intr.meta['deprecated'] and intr.meta['deprecated'].lower() == 'true' %}
-          <span class="label label-danger depwarn">Deprecated</span>
-        {% endif %}
+        {{ deprecated(intr) }}
     </h3></div>
     {% if intr.doc or meta_list(intr.meta)|trim %}
       <div class="panel-body">
@@ -408,9 +404,7 @@
 
 {% macro proc_line(proc,link=True,proto=False) %}
   {% if proc.mp %}module procedure {% if not proc.parent or (proc.visible and link) %}{{ proc }}{% else %}{{ proc.name }}{% endif %} <small>{% endif %}{% if (proc.parobj == 'module' or (proc.parobj == 'interface' and proc.parent.parobj == 'module')) and not proto %}{{ proc.permission }} {% endif %}{% for attrib in proc.attribs -%}{{ attrib }}{#{% if not loop.last or proc.module %}#} {#{% endif %}#}{%- endfor %}{% if proc.module and proc.module != True and (proc.parobj == 'interface' or proc.parobj == 'submodule') %}module {% endif %}{{ proc.proctype|lower }} {% if not proc.parent or (proc.visible and link and not proc.mp) %}{{ proc }}{% else %}{{ proc.name }}{% endif %}({% for arg in proc.args -%}{{ arg.name }}{% if not loop.last -%}, {% endif %}{%- endfor %}){% if proc.proctype|lower == 'function' and proc.name != proc.retvar.name %} result({{ proc.retvar.name }}){% endif %}{% if proc.bindC %} bind({{ proc.bindC }}){% endif %}{% if proc.mp %}</small>{% endif %}
-  {% if proc.meta['deprecated'] and proc.meta['deprecated'].lower() == 'true' %}
-    <span class="label label-danger depwarn">Deprecated</span>
-  {% endif %}
+  {{ deprecated(proc) }}
   {% if proc.module and proc.module != True and proc.parobj == 'submodule' and proc.module.visible %}
     <a href='{{ proc.module.get_url() }}'><button type="button" class="btn btn-info depwarn">Interface &rarr;</button></a>
   {% endif %}
@@ -422,10 +416,8 @@
 
 {% macro final(proc) %}
   <div class="panel panel-default">
-    <div class="panel-heading codesum"><span class="anchor" id="{{ proc.anchor }}"></span><h3>final :: <strong>{{ proc.name }}</strong>
-        {% if proc.meta['deprecated'] and proc.meta['deprecated'].lower() == 'true' %}
-          <span class="label label-danger depwarn">Deprecated</span>
-        {% endif %}</h3></div>
+    <div class="panel-heading codesum"><span class="anchor" id="{{ proc.anchor }}"></span><h3>final :: <strong>{{ proc.name }}</strong> {{ deprecated(proc) }}
+    </h3></div>
         <div class="panel-body">
           {{ meta_list(proc.meta) }}
           {{ proc.doc }}
@@ -442,9 +434,7 @@
 {% macro type_summary(dtype) %}
   <div class="panel panel-default">
     <div class="panel-heading codesum"><span class="anchor" id="{{ dtype.anchor }}"></span><h3>type{% if dtype.parobj == 'module' %}, {{ dtype.permission }}{% endif %}{% if dtype.sequence %}, sequence {% endif %}{% for attrib in dtype.attributes -%}, {{ attrib }}{%- endfor %}{% if dtype.extends %}, extends({{ dtype.extends }}){% endif %} :: {% if dtype.visible %}{{ dtype }}{% else %}{{ dtype.name }}{% endif %}
-        {% if dtype.meta['deprecated'] and dtype.meta['deprecated'].lower() == 'true' %}
-          <span class="label label-danger depwarn">Deprecated</span>
-        {% endif %}
+        {{ deprecated(dtype) }}
     </h3></div>
     <div class="panel-body">
       {% if dtype.doc or (meta_list(dtype.meta)|trim and not dtype.visible) %}
@@ -509,9 +499,7 @@
         <a data-toggle="popover" data-html="true" tabindex="0"
            data-trigger="focus"
            data-content="<h4>Used Elsewhere:</h4>{% for item in com.other_uses %}{% if item != com %}<a href='{{ item.get_url() }}'>{% if item.parent.name -%}{{ item.parent.name }}{%- else -%}<em>unnamed</em>{%- endif %}</a> ({% if item.parobj == 'proc' -%}{{ item.parent.proctype|lower }}{%- else -%}{{ item.parobj }}{%- endif %})<br>{% endif %}{% endfor %}">common{% if com.name %} /{{ com.name }}/{% endif %}</a>
-           {% if com.meta['deprecated'] and com.meta['deprecated'].lower() == 'true' %}
-             <span class="label label-danger depwarn">Deprecated</span>
-           {% endif %}
+           {{ deprecated(com) }}
     </h3></div>
     <div class="panel-body">
       {% if meta_list(com.meta)|trim %}
@@ -528,7 +516,7 @@
 
 {% macro enum_entry(enum) %}
   <div class="panel panel-default">
-    <div class="panel-heading codesum"><span class="anchor" id="{{ enum.anchor }}"></span><h3>enum, bind(c){% if enum.meta['deprecated'] and enum.meta['deprecated'].lower() == 'true' %}<span class="label label-danger depwarn">Deprecated</span>{% endif %}</h3></div>
+    <div class="panel-heading codesum"><span class="anchor" id="{{ enum.anchor }}"></span><h3>enum, bind(c){{ deprecated(enum) }}</h3></div>
     <div class="panel-body">
       <h4>Enumerators</h4>
       <table class="table table-striped varlist">

--- a/ford/templates/mod_page.html
+++ b/ford/templates/mod_page.html
@@ -5,9 +5,7 @@
   <div class="row">
     <h1>{{ module.name }} 
     <small>{% if module.obj == 'submodule' %}Submodule{% else %}Module{% endif %}</small>
-    {% if module.meta['deprecated'] and module.meta['deprecated'].lower() == 'true' %}
-   <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+    {{ macros.deprecated(module) }}
     </h1>
     {{ macros.info_bar(module, incl_src, project_url, module.lines_description(project.mod_lines)) }}
   </div>

--- a/ford/templates/nongenint_page.html
+++ b/ford/templates/nongenint_page.html
@@ -5,10 +5,8 @@
   {% import 'macros.html' as macros %}
   <div class="row">
     <h1>{{ interface.name }}
-   <small>{% if interface.abstract -%}Abstract {% endif %}Interface</small>
-    {% if interface.meta['deprecated'] and interface.meta['deprecated'].lower() == 'true' %}
-    <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      <small>{% if interface.abstract -%}Abstract {% endif %}Interface</small>
+      {{ macros.deprecated(interface) }}
     </h1>
     {% if interface.abstract %}
     {{

--- a/ford/templates/proc_page.html
+++ b/ford/templates/proc_page.html
@@ -5,9 +5,7 @@
   <div class="row">
     <h1>{{ procedure.name }}
       <small>{%if procedure.module %}Module {% endif %}{% if not procedure.mp %}{{ procedure.proctype }}{% else %}Procedure{% endif %}</small>
-    {% if procedure.meta['deprecated'] and procedure.meta['deprecated'].lower() == 'true' %}
-   <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      {{ macros.deprecated(procedure) }}
     </h1>
     {{
     macros.info_bar(procedure, incl_src, project_url, procedure.lines_description(project.proc_lines)) }}

--- a/ford/templates/prog_page.html
+++ b/ford/templates/prog_page.html
@@ -4,10 +4,8 @@
   {% import 'macros.html' as macros %}
   <div class="row">
     <h1>{% if program.name -%}{{ program.name }}{% else %}<em>unnamed</em>{% endif %}
-    <small>Program</small>
-    {% if program.meta['deprecated'] and program.meta['deprecated'].lower() == 'true' %}
-   <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      <small>Program</small>
+      {{ macros.deprecated(program) }}
     </h1>
     {{ macros.info_bar(program, incl_src, project_url, program.lines_description(project.prog_lines)) }}
   </div>

--- a/ford/templates/type_page.html
+++ b/ford/templates/type_page.html
@@ -55,42 +55,45 @@
     {% endif %}
     
     {% if dtype.constructor %}
-   <section>
-   <h2>Constructor</h2>
-     {% if dtype.constructor.obj == "interface" %}
-     {{ macros.interface(dtype.constructor) }}
-     {% elif dtype.constructor.obj == "subroutine" or dtype.constructor.obj == "function" %}
-      {% set obj = dtype.constructor %}
-       <div class="panel panel-default">
-        <div class="panel-heading codesum"><span class="anchor" id="{{ obj.anchor }}"></span><h3>{{ macros.proc_line(obj) }}</h3></div>
-         <div class="panel-body">
-          {{ macros.proc_summary(obj,False) }}
+      <section>
+        <h2>Constructor</h2>
+        {% if dtype.constructor.obj == "interface" %}
+          {{ macros.interface(dtype.constructor) }}
+        {% elif dtype.constructor.obj in ["subroutine", "function"] %}
+          {% set obj = dtype.constructor %}
+          <div class="panel panel-default">
+            <div class="panel-heading codesum">
+              <span class="anchor" id="{{ obj.anchor }}"></span>
+              <h3>{{ macros.proc_line(obj) }}</h3>
+            </div>
+            <div class="panel-body">
+              {{ macros.proc_summary(obj, full_docstring=True) }}
+            </div>
           </div>
-        </div>
-     {% endif %}
-   </section>
-   <br>
+        {% endif %}
+      </section>
+      <br>
     {% endif %}
-    
-    {% if dtype.finalprocs|length > 0 %}
-    <section>
-    <h2>Finalization Procedures</h2>
-     {% for proc in dtype.finalprocs %}
-         {{ macros.final(proc) }}
-       {% endfor %}  
-    </section>
-    <br>
+
+    {% if dtype.finalprocs %}
+      <section>
+        <h2>Finalization Procedures</h2>
+        {% for proc in dtype.finalprocs %}
+          {{ macros.final(proc) }}
+        {% endfor %}
+      </section>
+      <br>
     {% endif %}
-    
-    {% if dtype.boundprocs|length > 0 %} 
-    <section>
-    <h2>Type-Bound Procedures</h2>
-    {% for bp in dtype.boundprocs %}
-     {{ macros.bound_info(bp) }}
-    {% endfor %}
-    </section>
+
+    {% if dtype.boundprocs %}
+      <section>
+        <h2>Type-Bound Procedures</h2>
+        {% for bp in dtype.boundprocs %}
+          {{ macros.bound_info(bp) }}
+        {% endfor %}
+      </section>
     {% endif %}
-    
+
     {% if dtype.src %}
     <section>
     <h3><span class="anchor" id="src"></span>Source Code</h3>

--- a/ford/templates/type_page.html
+++ b/ford/templates/type_page.html
@@ -4,10 +4,8 @@
   {% import 'macros.html' as macros %}
   <div class="row">
     <h1>{{ dtype.name }}
-    <small>Derived Type</small>
-    {% if dtype.meta['deprecated'] and dtype.meta['deprecated'].lower() == 'true' %}
-   <span class="label label-danger depwarn">Deprecated</span>
-    {% endif %}
+      <small>Derived Type</small>
+      {{ macros.deprecated(dtype) }}
     </h1>
     {{ macros.info_bar(dtype, incl_src, project_url, dtype.lines_description(project.type_lines,project.type_lines_all)) }}
   </div>

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -271,3 +271,20 @@ def test_deprecated(example_project):
 
     apply_check_box = index.find(id="proc-apply_check").parent
     assert apply_check_box.h3.span.text == "Deprecated"
+
+
+def test_private_procedure_links(example_project):
+    path, _ = example_project
+    index = read_html(path / "type/example_type.html")
+
+    subroutine_box = index.find("h3", string=re.compile("example_type_say"))
+    assert subroutine_box.a is None
+
+
+def test_public_procedure_links(example_project):
+    path, _ = example_project
+    index = read_html(path / "module/test_module.html")
+
+    subroutine_box = index.find(id="proc-increment").parent
+    assert subroutine_box.a is not None
+    assert subroutine_box.a["href"] == "../proc/increment.html"

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -263,3 +263,11 @@ def test_variable_lists(example_project):
     expected_declaration = "real(kind=real64) :: global_pi = acos(-1) a global variable, initialized to the value of pi"
     declaration_no_whitespace = varlist.tbody.text.replace("\n", "").replace(" ", "")
     assert declaration_no_whitespace == expected_declaration.replace(" ", "")
+
+
+def test_deprecated(example_project):
+    path, _ = example_project
+    index = read_html(path / "module/test_module.html")
+
+    apply_check_box = index.find(id="proc-apply_check").parent
+    assert apply_check_box.h3.span.text == "Deprecated"

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -3,6 +3,7 @@ import sys
 import os
 import pathlib
 import re
+from urllib.parse import urlparse
 
 import ford
 
@@ -158,10 +159,52 @@ def test_types_type_bound_procedure(example_project):
 
     bound_procedures_section = index.find("h2", string="Type-Bound Procedures").parent
 
-    assert "This will document" in bound_procedures_section.text, "Binding docstring"
+    assert "This will document" in bound_procedures_section.text, "Binding summary"
     assert (
-        "has more documentation" in bound_procedures_section.text
-    ), "Full procedure docstring"
+        "This binding has more documentation" in bound_procedures_section.text
+    ), "Binding full docstring"
+    assert (
+        "Prints how many times" in bound_procedures_section.ul.text
+    ), "Full procedure summary"
+    assert (
+        "This subroutine has more documentation" in bound_procedures_section.ul.text
+    ), "Full procedure full docstring"
+
+
+def test_types_constructor_summary(example_project):
+    path, _ = example_project
+    index = read_html(path / "type/example_type.html")
+
+    constructor_section = index.find("h2", string="Constructor").parent
+
+    assert "This is a constructor for our type" in constructor_section.text
+    assert "This constructor has more documentation" in constructor_section.text
+    assert "specific constructor" in constructor_section.ul.text
+    assert "More documentation" in constructor_section.ul.text
+
+
+def test_types_constructor_page(example_project):
+    path, _ = example_project
+    index = read_html(path / "interface/example_type.html")
+
+    constructor_section = index.find("h2", string=re.compile("example_type")).parent
+
+    assert "This is a constructor for our type" in constructor_section.text
+    assert "This constructor has more documentation" in constructor_section.text
+    assert "specific constructor" in constructor_section.text
+    assert "More documentation" in constructor_section.text
+
+
+def test_types_finaliser(example_project):
+    path, _ = example_project
+    index = read_html(path / "type/example_type.html")
+
+    finaliser_section = index.find("h2", string="Finalization Procedures").parent
+
+    assert "This is the finaliser" in finaliser_section.text
+    assert "This finaliser has more documentation" in finaliser_section.text
+    assert "Cleans up" in finaliser_section.ul.text
+    assert "More documentation" in finaliser_section.ul.text
 
 
 def test_graph_submodule(example_project):
@@ -238,6 +281,12 @@ def test_side_panel(example_project):
     assert (
         constructor_panel.a["href"]
         == "../type/example_type.html#interface-example_type"
+    )
+    finaliser_panel = type_index.find(id="fins-1")
+    assert finaliser_panel.a.text == "example_type_finalise"
+    assert (
+        finaliser_panel.a["href"]
+        == "../type/example_type.html#finalproc-example_type_finalise"
     )
 
     check_index = read_html(path / "interface/check.html")

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1,9 +1,9 @@
-from ford.sourceform import FortranSourceFile
 from ford.fortran_project import Project
 from ford import DEFAULT_SETTINGS
 from ford.utils import normalise_path
 
 from copy import deepcopy
+from itertools import chain
 
 import markdown
 import pytest
@@ -925,3 +925,63 @@ def test_submodule_uses(copy_fortran_file):
 
     assert mod_d.parent_submodule == mod_c
     assert mod_d.ancestor_module == mod_a
+
+
+def test_make_links(copy_fortran_file):
+    links = "[[a]] [[b]] [[b:c]] [[d]] [[b:e]] [[f]] [[a:g]] [[h]]"
+
+    data = f"""\
+    module a !! {links}
+      type b !! {links}
+        integer :: c !! {links}
+      contains
+        final :: d !! {links}
+        procedure :: e !! {links}
+      end type b
+
+      interface b !! {links}
+        module procedure f
+      end interface b
+
+      type(b) :: g !! {links}
+    contains
+      subroutine d(self) !! {links}
+        type(b) :: self !! {links}
+      end subroutine d
+      subroutine e(self) !! {links}
+        class(b) :: self !! {links}
+      end subroutine e
+      function f() !! {links}
+        type(b) :: f !! {links}
+      end function f
+    end module a
+
+    program h !! {links}
+    end program h
+    """
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+
+    project.make_links()
+
+    expected_links = {
+        "a": "../module/a.html",
+        "b": "../type/b.html",
+        "c": "../type/b.html#variable-c",
+        "d": "../proc/d.html",
+        "e": "../type/b.html#boundprocedure-e",
+        "f": "../proc/f.html",
+        "g": "../module/a.html#variable-g",
+        "h": "../program/h.html",
+    }
+
+    for item in chain(
+        project.files[0].children,
+        project.types[0].children,
+        project.procedures[0].children,
+        project.procedures[2].children,
+    ):
+        docstring = BeautifulSoup(item.doc, features="html.parser")
+        link_locations = {a.string: a.get("href", None) for a in docstring("a")}
+
+        assert link_locations == expected_links, (item, item.name)

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1372,3 +1372,16 @@ def test_url(parse_fortran_file):
         .get_url()
         .endswith("/module/mod_foo.html#variable-real_foo")
     )
+
+
+def test_single_character_interface(parse_fortran_file):
+    data = """\
+    module a
+      interface b !! some comment
+        module procedure c
+      end interface b
+    end module a
+    """
+    fortran_file = parse_fortran_file(data)
+    assert fortran_file.modules[0].interfaces[0].name == "b"
+    assert fortran_file.modules[0].interfaces[0].doc == [" some comment"]


### PR DESCRIPTION
Fixes #456 

Also a few other bugs I found at the same time:
- Bad link in readme
- Repeated type in docs
- Single-letter interface names weren't recognised
- Links in type finalisers and constructors weren't expanded

I'm not sure this is the best solution, as it might be a bit over-eager and use the full docstring in places where we would actually only want the summary. I don't have time to look into this much more though, but I suspect the actual link we want may also be context dependent.