### PR TITLE
Fix `src_dir` command line option

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -288,8 +288,9 @@ def get_command_line_arguments() -> argparse.Namespace:
     parser.add_argument(
         "-e",
         "--extensions",
-        action="append",
-        help="extensions which should be scanned for documentation (default: f90, f95, f03, f08)",
+        nargs="+",
+        default=["f90", "f95", "f03", "f08"],
+        help="extensions which should be scanned for documentation",
     )
     parser.add_argument(
         "-m",
@@ -353,13 +354,14 @@ def get_command_line_arguments() -> argparse.Namespace:
         "-I",
         "--include",
         action="append",
-        help="list of directories to be searched for `include` files",
+        help="list of directories to be searched for ``include`` files",
     )
     parser.add_argument(
         "--externalize",
         action="store_const",
         const="true",
-        help="provide information about Fortran objects in a json database for other FORD projects to refer to.",
+        help="provide information about Fortran objects in a json database for "
+        "other FORD projects to refer to.",
     )
     parser.add_argument(
         "-L",

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -251,7 +251,7 @@ def get_command_line_arguments() -> argparse.Namespace:
     parser.add_argument(
         "-d",
         "--src_dir",
-        action="append",
+        nargs="+",
         default=["./src"],
         help="directories containing all source files for the project",
     )

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -241,7 +241,9 @@ def get_command_line_arguments() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(
         "ford",
-        description="Document a program or library written in modern Fortran. Any command-line options over-ride those specified in the project file.",
+        description="Document a program or library written in modern Fortran. "
+        "Any command-line options over-ride those specified in the project file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "project_file",

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -1,5 +1,6 @@
 import ford
 from textwrap import dedent
+import sys
 import pytest
 
 from conftest import gfortran_is_not_installed
@@ -133,3 +134,27 @@ def test_gfortran_preprocessor():
     data, _, _ = ford.parse_arguments({}, "preprocessor: gfortran -E")
 
     assert data["preprocess"] is True
+
+
+def test_absolute_src_dir(monkeypatch, tmp_path):
+    project_file = tmp_path / "example.md"
+    project_file.touch()
+    src_dir = str(tmp_path / "not_here")
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", ["ford", str(project_file)])
+        args = ford.get_command_line_arguments()
+
+    assert args.src_dir == ["./src"]
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", ["ford", str(project_file), "--src_dir", src_dir])
+        args = ford.get_command_line_arguments()
+
+    assert args.src_dir == [src_dir]
+
+    with monkeypatch.context() as m:
+        m.setattr(sys, "argv", ["ford", "--src_dir", src_dir, "--", str(project_file)])
+        args = ford.get_command_line_arguments()
+
+    assert args.src_dir == [src_dir]


### PR DESCRIPTION
Fixes #458 

Minor breaking change: `--src_dir` consumes multiple arguments, so the project file must not immediately follow it:

```
$ ford --src_dir ./source docs.md # Error
$ ford docs.md --src_dir ./source # Ok
$ ford --src_dir ./source -- docs.md # Ok
```

Having looked at every project using FORD that I can see, this will not affect any of them (at least in their automated doc builds)