### PR TITLE
Fix setuptools deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/Fortran-FOSS-Programmers/ford
 author = Chris MacMackin
 author_email = cmacmackin@gmail.com
 license = GPLv3
-license_file = LICENSE
+license_files = LICENSE
 keywords = Markdown, Fortran, documentation, comments
 classifiers =
     Development Status :: 5 - Production/Stable
@@ -27,7 +27,7 @@ project_urls =
     Tracker = https://github.com/Fortran-FOSS-Programmers/ford/issues
 
 [options]
-packages = ford
+packages = find_namespace:
 install_requires =
    markdown ~= 3.4.0
    markdown-include ~= 0.7.0
@@ -40,6 +40,9 @@ install_requires =
    tqdm ~= 4.64.0
    importlib-metadata; python_version < "3.8"
 include_package_data = True
+
+[options.packages.find]
+include = ford*
 
 [options.extras_require]
 tests = pytest >= 3.3.0


### PR DESCRIPTION
On install Ford-6.1.17 gentoo user repository (Gentoo GURU) package that built from PyPi source tarball the following warnings appears:
```
* QA Notice: setuptools warnings detected: *
*   Installing 'ford.css' as data is deprecated, please list it in `packages`.
*   Installing 'ford.fonts' as data is deprecated, please list it in `packages`.
*   Installing 'ford.js' as data is deprecated, please list it in `packages`.
*   Installing 'ford.templates' as data is deprecated, please list it in `packages`.
*   Installing 'ford.tipuesearch' as data is deprecated, please list it in `packages`.
*   Installing 'ford.tipuesearch.img' as data is deprecated, please list it in `packages`.
*   The license_file parameter is deprecated, use license_files instead.
```
The proposed patch should fix it and store the same list of files to install into system.

P.S.  
**I hope that offered solution will not brake the build and install process
at least the installed list of files remains the same as before applying this patch**
