### PR TITLE
Handle procedure pointers and dummy procedures in interface blocks

### DIFF
--- a/example/src/ford_interfaces.f90
+++ b/example/src/ford_interfaces.f90
@@ -1,0 +1,43 @@
+module interfaces
+  !! This module demostrates how FORD handles various aspects of
+  !! interfaces
+
+  abstract interface
+    integer pure function unary_f_t(n)
+      !! This defines a named interface for some functions with the
+      !! same signature
+      implicit none
+      integer, intent(in) :: n
+      !! Scalar number
+    end function unary_f_t
+  end interface
+
+  procedure(unary_f_t), pointer, public :: unary_f => null()
+  !! This is a procedure pointer with a named interface
+
+  interface generic_unary_f
+    !! This is an interface that gives a generic name to multiple
+    !! specific (distinguishable) implementations
+    procedure unary_f
+      !! This is pointer procedure above
+
+    real pure function real_unary_f(x)
+      !! A `real` version of our function
+      real, intent(in) :: x
+    end function real_unary_f
+
+    module procedure :: higher_order_unary_f
+      !! A function defined in this module
+  end interface generic_unary_f
+
+contains
+
+  pure integer function higher_order_unary_f(f, n)
+    !! This is `apply`
+    procedure(unary_f_t) :: f
+      !! Some function to apply
+    integer, intent(in) :: n
+      !! Number to call `f` with
+    higher_order_unary_f = f(n)
+  end function higher_order_unary_f
+end module interfaces

--- a/ford/fixed2free2.py
+++ b/ford/fixed2free2.py
@@ -130,7 +130,6 @@ def convertToFree(stream, length_limit=True):
 
 
 if __name__ == "__main__":
-
     if len(sys.argv) > 1:
         with open(sys.argv[1], "r") as infile:
             for line in convertToFree(infile):

--- a/ford/pagetree.py
+++ b/ford/pagetree.py
@@ -104,7 +104,6 @@ class PageNode(object):
 
 
 def get_page_tree(topdir, proj_copy_subdir, md, parent=None):
-
     # In python 3.6 or newer, the normal dict is guaranteed to be ordered.
     # However, to keep compatibility with older versions I use OrderedDict.
     # I will use this later to remove duplicates from a list in a short way.

--- a/ford/reader.py
+++ b/ford/reader.py
@@ -231,7 +231,6 @@ class FortranReader(object):
         linebuffer = ""
 
         while not done:
-
             line = next(self.reader)
 
             self.line_number += 1

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1913,6 +1913,9 @@ class FortranType(FortranContainer):
         for obj in self.boundprocs + self.variables:
             obj.visible = True
 
+    def __repr__(self):
+        return f"FortranType('{self.name}', variables={self.variables}, boundprocs={self.boundprocs})"
+
 
 class FortranEnum(FortranContainer):
     """
@@ -2174,6 +2177,9 @@ class FortranVariable(FortranBase):
         attributes = [f", {part}" for part in attribute_parts]
         return f"{self.full_type}{''.join(attributes)}"
 
+    def __repr__(self):
+        return f"FortranVariable('{self.name}', type='{self.full_type}', permission='{self.permission}')"
+
 
 class FortranBoundProcedure(FortranBase):
     """
@@ -2253,6 +2259,9 @@ class FortranBoundProcedure(FortranBase):
             #    self.bindings[i] = FortranSpoof(self.bindings[i], self.parent, 'BOUNDPROC')
 
         self.sort_components()
+
+    def __repr__(self):
+        return f"FortranBoundProcedure('{self.name}', permission='{self.permission}')"
 
 
 class FortranModuleProcedure(FortranBase):

--- a/ford/templates/genint_page.html
+++ b/ford/templates/genint_page.html
@@ -9,64 +9,63 @@
     </h1>
     {{ macros.info_bar(interface, incl_src, project_url, interface.lines_description(project.proc_lines,project.proc_lines,'proc')) }}
   </div>
-  
+
   <div class="row">
     <div class="col-md-3 hidden-xs hidden-sm visible-md visible-lg">
       {{ macros.sidebar(project,interface) }}
     </div>
-    
+
     <div class="col-md-9" id='text'>
       <h2>{{ interface.permission }} interface {{ interface.name }}</h2>
-   {{ interface.doc }}
-     {% if interface.callsgraph %}
-    <div class="panel panel-default">
-      <div class="panel-heading">
-  <h3 class="panel-title">Calls</h3>
-      </div>
-      <div class="panel-body">
-  {{ interface.callsgraph }}
-      </div>
+      {{ interface.doc }}
+      {% if interface.callsgraph %}
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Calls</h3>
+          </div>
+          <div class="panel-body">
+            {{ interface.callsgraph }}
+          </div>
+        </div>
+      {% endif %}
+      {% if interface.calledbygraph %}
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title">Called by</h3>
+          </div>
+          <div class="panel-body">
+            {{ interface.calledbygraph }}
+          </div>
+        </div>
+      {% endif %}
+      {% if interface.doc or interface.callsgraph or interface.calledbygraph %}<br>{% endif %}
+
+      <section class="visible-xs visible-sm hidden-md">
+        {{ macros.content_list(interface,1) }}
+      </section>
+      <br class="visible-xs visible-sm hidden-md">
+
+      {% if interface.functions %}
+        <h2>Functions</h2>
+        {% for proc in interface.functions %}
+          {{ macros.proc_entry(proc) }}
+        {% endfor %}
+      {% endif %}
+
+      {% if interface.subroutines %}
+        <h2>Subroutines</h2>
+        {% for proc in interface.subroutines %}
+          {{ macros.proc_entry(proc) }}
+        {% endfor %}
+      {% endif %}
+
+      {% if interface.modprocs %}
+        <h2>Module Procedures</h2>
+        {% for proc in interface.modprocs %}
+          {{ macros.proc_entry(proc.procedure) }}
+        {% endfor %}
+      {% endif %}
+
     </div>
-     {% endif %}
-     {% if interface.calledbygraph %}
-    <div class="panel panel-default">
-      <div class="panel-heading">
-  <h3 class="panel-title">Called by</h3>
-      </div>
-      <div class="panel-body">
-     {{ interface.calledbygraph }}
-      </div>
-    </div>
-     {% endif %}
-    {% if interface.doc or interface.callsgraph or interface.calledbygraph %}<br>{% endif %}
-
-     <section class="visible-xs visible-sm hidden-md">
-       {{ macros.content_list(interface,1) }}
-     </section>
-     <br class="visible-xs visible-sm hidden-md">
-     
-  {% if interface.functions %}
-   <h2>Functions</h2>
-   {% for proc in interface.functions %}
-    {{ macros.proc_entry(proc) }}
-   {% endfor %}
-     {% endif %}
-
-  {% if interface.subroutines %}
-   <h2>Subroutines</h2>
-   {% for proc in interface.subroutines %}
-    {{ macros.proc_entry(proc) }}
-   {% endfor %}
-     {% endif %}
-
-  {% if interface.modprocs %}
-   <h2>Module Procedures</h2>
-   {% for proc in interface.modprocs %}
-    {{ macros.proc_entry(proc.procedure) }}
-   {% endfor %}
-     {% endif %}
-
- </div>
-</div>
-
+  </div>
 {% endblock body %}

--- a/ford/templates/genint_page.html
+++ b/ford/templates/genint_page.html
@@ -45,21 +45,21 @@
      </section>
      <br class="visible-xs visible-sm hidden-md">
      
-  {% if interface.functions|length > 0 %}
+  {% if interface.functions %}
    <h2>Functions</h2>
    {% for proc in interface.functions %}
     {{ macros.proc_entry(proc) }}
    {% endfor %}
      {% endif %}
 
-  {% if interface.subroutines|length > 0 %}
+  {% if interface.subroutines %}
    <h2>Subroutines</h2>
    {% for proc in interface.subroutines %}
     {{ macros.proc_entry(proc) }}
    {% endfor %}
      {% endif %}
 
-  {% if interface.modprocs|length > 0 %}
+  {% if interface.modprocs %}
    <h2>Module Procedures</h2>
    {% for proc in interface.modprocs %}
     {{ macros.proc_entry(proc.procedure) }}

--- a/ford/templates/genint_page.html
+++ b/ford/templates/genint_page.html
@@ -66,6 +66,10 @@
         {% endfor %}
       {% endif %}
 
+      {%- if interface.variables -%}
+        <h2>Dummy Procedures and Procedure Pointers</h2>
+        {{ macros.variable_list(interface.variables, permission=False) }}
+      {%- endif -%}
     </div>
   </div>
 {% endblock body %}

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -388,6 +388,12 @@
             {{ proc_summary(proc.procedure, full_docstring=full_docstring) }}
           </li>
         {% endfor %}
+        {%- if intr.variables -%}
+          <li class="list-group-item">
+            <h3>Dummy Procedures and Procedure Pointers</h3>
+            {{ variable_list(intr.variables, permission=False) }}
+          </li>
+        {%- endif -%}
       {% else %}
         <li class="list-group-item">
           {{ proc_summary(intr.procedure, full_docstring=full_docstring) }}

--- a/ford/templates/mod_page.html
+++ b/ford/templates/mod_page.html
@@ -17,9 +17,7 @@
     
     <div class="col-md-9" id='text'>
     {{ module.doc }}
-      {% if module.uses|length > 0 or (module.ancestry and
-      module.ancestry|length > 0) or module.usedbygraph or (module.descendants
-      and module.descendants|length > 0) %}<br>{% endif %}
+      {% if module.uses or module.ancestry or module.usedbygraph or module.descendants %}<br>{% endif %}
     {{ macros.use_list(module) }}
     {{ macros.usedby_list(module) }}
     <br>
@@ -29,7 +27,7 @@
     </section>
     <br class="visible-xs visible-sm hidden-md">
 
-    {% if module.common|length > 0 %}
+    {% if module.common %}
     <section>
       <h2>Common Blocks</h2>
       {% for com in module.common %}
@@ -44,7 +42,7 @@
     </script>
     {% endif %}
 
-    {% if module.variables|length > 0 %}
+    {% if module.variables %}
     <section>
     <h2>Variables</h2>
     {{ macros.variable_list(module.variables, permission=True) }}
@@ -52,7 +50,7 @@
     <br>
     {% endif %}
     
-    {% if module.enums|length > 0 %}
+    {% if module.enums %}
     <section>
     <h2>Enumerations</h2>
     {% for enum in module.enums %}
@@ -62,7 +60,7 @@
     <br>
     {% endif %}
     
-    {% if module.interfaces|length > 0 %}
+    {% if module.interfaces %}
     <section>
    <h2>Interfaces</h2>
    {% for intr in module.interfaces %}
@@ -72,7 +70,7 @@
   <br>
     {% endif %}
 
-    {% if module.absinterfaces|length > 0 %}
+    {% if module.absinterfaces %}
     <section>
      <h2>Abstract Interfaces</h2>
    {% for intr in module.absinterfaces %}
@@ -82,7 +80,7 @@
   <br>
     {% endif %}
     
-    {% if module.types|length > 0 %}
+    {% if module.types %}
     <section>
      <h2>Derived Types</h2>
    {% for type in module.types %}
@@ -92,7 +90,7 @@
   <br>
     {% endif %}
     
-    {% if module.functions|length > 0 %} 
+    {% if module.functions %} 
     <section>
     <h2>Functions</h2>
     {% for proc in module.functions %}
@@ -102,7 +100,7 @@
     <br>
     {% endif %}
 
-    {% if module.subroutines|length > 0 %}
+    {% if module.subroutines %}
     <section>
     <h2>Subroutines</h2>
     {% for proc in module.subroutines %}

--- a/ford/templates/mod_page.html
+++ b/ford/templates/mod_page.html
@@ -3,142 +3,142 @@
 {% block body %}
   {% import 'macros.html' as macros %}
   <div class="row">
-    <h1>{{ module.name }} 
-    <small>{% if module.obj == 'submodule' %}Submodule{% else %}Module{% endif %}</small>
-    {{ macros.deprecated(module) }}
+    <h1>{{ module.name }}
+      <small>{% if module.obj == 'submodule' %}Submodule{% else %}Module{% endif %}</small>
+      {{ macros.deprecated(module) }}
     </h1>
     {{ macros.info_bar(module, incl_src, project_url, module.lines_description(project.mod_lines)) }}
   </div>
-  
+
   <div class="row">
     <div class="col-md-3 hidden-xs hidden-sm visible-md visible-lg">
-    {{ macros.sidebar(project,module) }}
+      {{ macros.sidebar(project,module) }}
     </div>
-    
+
     <div class="col-md-9" id='text'>
-    {{ module.doc }}
+      {{ module.doc }}
       {% if module.uses or module.ancestry or module.usedbygraph or module.descendants %}<br>{% endif %}
-    {{ macros.use_list(module) }}
-    {{ macros.usedby_list(module) }}
-    <br>
-
-    <section class="visible-xs visible-sm hidden-md">
-      {{ macros.content_list(module,1) }}
-    </section>
-    <br class="visible-xs visible-sm hidden-md">
-
-    {% if module.common %}
-    <section>
-      <h2>Common Blocks</h2>
-      {% for com in module.common %}
-      {{ macros.common_block(com) }}
-      {% endfor %}
-    </section>
-    <br>
-    <script>
-    $(function () {
-    $('[data-toggle="popover"]').popover()
-    })
-    </script>
-    {% endif %}
-
-    {% if module.variables %}
-    <section>
-    <h2>Variables</h2>
-    {{ macros.variable_list(module.variables, permission=True) }}
-    </section>
-    <br>
-    {% endif %}
-    
-    {% if module.enums %}
-    <section>
-    <h2>Enumerations</h2>
-    {% for enum in module.enums %}
-      {{ macros.enum_entry(enum) }}
-    {% endfor %}
-    </section>
-    <br>
-    {% endif %}
-    
-    {% if module.interfaces %}
-    <section>
-   <h2>Interfaces</h2>
-   {% for intr in module.interfaces %}
-     {{ macros.interface(intr) }}
-    {% endfor %}
-    </section>
-  <br>
-    {% endif %}
-
-    {% if module.absinterfaces %}
-    <section>
-     <h2>Abstract Interfaces</h2>
-   {% for intr in module.absinterfaces %}
-     {{ macros.absinterface(intr) }}
-    {% endfor %}
-    </section>
-  <br>
-    {% endif %}
-    
-    {% if module.types %}
-    <section>
-     <h2>Derived Types</h2>
-   {% for type in module.types %}
-     {{ macros.type_summary(type) }}
-     {% endfor %}
-    </section>
-  <br>
-    {% endif %}
-    
-    {% if module.functions %} 
-    <section>
-    <h2>Functions</h2>
-    {% for proc in module.functions %}
-    {{ macros.proc_entry(proc) }}
-    {% endfor %}
-    </section>
-    <br>
-    {% endif %}
-
-    {% if module.subroutines %}
-    <section>
-    <h2>Subroutines</h2>
-    {% for proc in module.subroutines %}
-    {{ macros.proc_entry(proc) }}
-    {% endfor %}
-    </section>
-    <br>
-    {% endif %}
-
-    {% if module.modfunctions %}
-      <section>
-        <h2>Module Functions</h2>
-        {% for proc in module.modfunctions %}
-          {{ macros.proc_entry(proc) }}
-        {% endfor %}
-      </section>
+      {{ macros.use_list(module) }}
+      {{ macros.usedby_list(module) }}
       <br>
-    {% endif %}
 
-    {% if module.modsubroutines %}
-      <section>
-        <h2>Module Subroutines</h2>
-        {% for proc in module.modsubroutines %}
-          {{ macros.proc_entry(proc) }}
-        {% endfor %}
+      <section class="visible-xs visible-sm hidden-md">
+        {{ macros.content_list(module,1) }}
       </section>
-      <br>
-    {% endif %}
+      <br class="visible-xs visible-sm hidden-md">
 
-    {% if module.modprocedures %}
-      <section>
-        <h2>Module Procedures</h2>
-        {% for proc in module.modprocedures %}
-          {{ macros.proc_entry(proc) }}
-        {% endfor %}
-      </section>
-    {% endif %}
+      {% if module.common %}
+        <section>
+          <h2>Common Blocks</h2>
+          {% for com in module.common %}
+            {{ macros.common_block(com) }}
+          {% endfor %}
+        </section>
+        <br>
+        <script>
+          $(function () {
+          $('[data-toggle="popover"]').popover()
+          })
+        </script>
+      {% endif %}
+
+      {% if module.variables %}
+        <section>
+          <h2>Variables</h2>
+          {{ macros.variable_list(module.variables, permission=True) }}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.enums %}
+        <section>
+          <h2>Enumerations</h2>
+          {% for enum in module.enums %}
+            {{ macros.enum_entry(enum) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.interfaces %}
+        <section>
+          <h2>Interfaces</h2>
+          {% for intr in module.interfaces %}
+            {{ macros.interface(intr) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.absinterfaces %}
+        <section>
+          <h2>Abstract Interfaces</h2>
+          {% for intr in module.absinterfaces %}
+            {{ macros.absinterface(intr) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.types %}
+        <section>
+          <h2>Derived Types</h2>
+          {% for type in module.types %}
+            {{ macros.type_summary(type) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.functions %}
+        <section>
+          <h2>Functions</h2>
+          {% for proc in module.functions %}
+            {{ macros.proc_entry(proc) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.subroutines %}
+        <section>
+          <h2>Subroutines</h2>
+          {% for proc in module.subroutines %}
+            {{ macros.proc_entry(proc) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.modfunctions %}
+        <section>
+          <h2>Module Functions</h2>
+          {% for proc in module.modfunctions %}
+            {{ macros.proc_entry(proc) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.modsubroutines %}
+        <section>
+          <h2>Module Subroutines</h2>
+          {% for proc in module.modsubroutines %}
+            {{ macros.proc_entry(proc) }}
+          {% endfor %}
+        </section>
+        <br>
+      {% endif %}
+
+      {% if module.modprocedures %}
+        <section>
+          <h2>Module Procedures</h2>
+          {% for proc in module.modprocedures %}
+            {{ macros.proc_entry(proc) }}
+          {% endfor %}
+        </section>
+      {% endif %}
     </div>
   </div>
 
-  {% endblock body %}
+{% endblock body %}

--- a/ford/tipue_search.py
+++ b/ford/tipue_search.py
@@ -47,7 +47,6 @@ except ImportError:
 
 class Tipue_Search_JSON_Generator(object):
     def __init__(self, output_path: os.PathLike, project_url: str):
-
         self.output_path = pathlib.Path(output_path)
         self.siteurl = project_url
         self.json_nodes = []

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -116,7 +116,12 @@ def test_source_file_links(example_index):
     source_files_list = sorted([f.text for f in source_files_box("li")])
 
     assert source_files_list == sorted(
-        ["ford_test_module.fpp", "ford_test_program.f90", "ford_example_type.f90"]
+        [
+            "ford_test_module.fpp",
+            "ford_test_program.f90",
+            "ford_example_type.f90",
+            "ford_interfaces.f90",
+        ]
     )
 
 
@@ -126,7 +131,9 @@ def test_module_links(example_index):
     modules_box = index.find(ANY_TEXT, string="Modules").parent
     modules_list = sorted([f.text for f in modules_box("li")])
 
-    assert modules_list == sorted(["test_module", "ford_example_type_mod"])
+    assert modules_list == sorted(
+        ["test_module", "ford_example_type_mod", "interfaces"]
+    )
 
 
 def test_procedures_links(example_index):
@@ -136,7 +143,15 @@ def test_procedures_links(example_index):
     proceduress_list = sorted([f.text for f in proceduress_box("li")])
 
     all_procedures = sorted(
-        ["decrement", "do_foo_stuff", "do_stuff", "increment", "check", "apply_check"]
+        [
+            "decrement",
+            "do_foo_stuff",
+            "do_stuff",
+            "increment",
+            "check",
+            "apply_check",
+            "higher_order_unary_f",
+        ]
     )
     max_frontpage_items = int(settings["max_frontpage_items"])
     front_page_list = all_procedures[:max_frontpage_items]
@@ -396,3 +411,26 @@ def test_submodule_procedure_implementation_links(example_project):
     check_impl_link = check_interface_heading.a
     assert "Implementation" in check_impl_link.text
     assert check_impl_link["href"].endswith("proc/check.html")
+
+
+def test_interfaces(example_project):
+    path, _ = example_project
+    interface_mod_page = read_html(path / "module/interfaces.html")
+
+    # Span inside the div we actually want, but this has an id
+    box_span = interface_mod_page.find(id="interface-generic_unary_f")
+    assert box_span
+
+    box = box_span.parent.parent
+
+    list_items = box("li")
+    list_item_titles = sorted([li.h3.text.strip() for li in list_items])
+    assert list_item_titles == sorted(
+        [
+            "public pure function real_unary_f(x)",
+            "public pure function higher_order_unary_f(f, n)",
+            "Dummy Procedures and Procedure Pointers",
+        ]
+    )
+
+    assert len(list_items[-1]("tr")) == 2

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1442,3 +1442,30 @@ def test_module_interface_same_name_as_interface(parse_fortran_file):
 
     modproc = module.modprocedures[0]
     assert modproc.name == "foo"
+
+
+def test_procedure_pointer(parse_fortran_file):
+    data = """\
+    module foo
+      abstract interface
+        integer pure function unary_f_t(n)
+          implicit none
+          integer, intent(in) :: n
+        end function
+      end interface
+
+      private
+
+      procedure(unary_f_t), pointer, public :: unary_f => null()
+
+      interface generic_unary_f
+        procedure unary_f
+      end interface
+    end module
+    """
+
+    fortran_file = parse_fortran_file(data)
+    module = fortran_file.modules[0]
+    module.correlate(None)
+    assert len(module.interfaces[0].modprocs) == 0
+    assert module.interfaces[0].variables[0].name == "unary_f"


### PR DESCRIPTION
Procedure pointers in `interface` blocks are now handled correctly and rendered as variables.

Fixes #477 

@mcocdawc If you're able, would you mind checking this branch for your use case?