### PR TITLE
Fix for max_frontpage_items

### DIFF
--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -97,9 +97,7 @@
               <h3>Source Files</h3>
               <ul>
                 {%- for src in (project.allfiles|sort(attribute='name'))[:max_length] -%}
-                  {% if loop.index0 < max_length %}
-                    <li>{{ src }}</li>
-                  {%- endif -%}
+                  <li>{{ src }}</li>
                 {%- endfor -%}
               </ul>
             </div>
@@ -116,9 +114,7 @@
               <h3>Modules</h3>
               <ul>
                 {%- for mod in (project.modules|sort(attribute='name'))[:max_length] -%}
-                  {% if loop.index0 < max_length %}
-                    <li>{{ mod }}</li>
-                  {%- endif -%}
+                  <li>{{ mod }}</li>
                 {%- endfor -%}
               </ul>
             </div>
@@ -135,9 +131,7 @@
               <h3>Procedures</h3>
               <ul>
                 {%- for proc in (project.procedures|sort(attribute='name'))[:max_length] -%}
-                  {% if loop.index0 < max_length %}
-                    <li>{{ proc }}</li>
-                  {%- endif -%}
+                  <li>{{ proc }}</li>
                 {%- endfor -%}
               </ul>
             </div>
@@ -154,9 +148,7 @@
               <h3>Derived Types</h3>
               <ul>
                 {%- for dtype in (project.types|sort(attribute='name'))[:max_length] -%}
-                  {% if loop.index0 < max_length %}
-                    <li>{{ dtype }}</li>
-                  {%- endif -%}
+                  <li>{{ dtype }}</li>
                 {%- endfor -%}
               </ul>
             </div>

--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -87,7 +87,7 @@
       {% if project.procedures|length > 0 %}{% set count = count + 1 %}{% endif %}
       {% if project.types|length > 0 %}{% set count = count + 1 %}{% endif %}
       {% set max_length = max_frontpage_items|int %}
-      {% if (count != 0) and (max_length > 0) %}
+      {% if count and max_length %}
         {% set width = (12/count)|int %}
         <div class="row">
           <hr>

--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -86,67 +86,88 @@
       {% if project.modules|length > 0 %}{% set count = count + 1 %}{% endif %}
       {% if project.procedures|length > 0 %}{% set count = count + 1 %}{% endif %}
       {% if project.types|length > 0 %}{% set count = count + 1 %}{% endif %}
-      {% if count != 0 %}
-		{% set width = (12/count)|int %}
-        {% set max_length = max_frontpage_items|int %}
-      <div class="row">
-        {% if incl_src %}
-        <div class="col-xs-6 col-sm-{{ width }}">
+      {% set max_length = max_frontpage_items|int %}
+      {% if (count != 0) and (max_length > 0) %}
+        {% set width = (12/count)|int %}
+        <div class="row">
+          <hr>
+          {% if incl_src %}
+          <div class="col-xs-6 col-sm-{{ width }}">
+            <div>
               <h3>Source Files</h3>
               <ul>
                 {%- for src in (project.allfiles|sort(attribute='name'))[:max_length] -%}
                   {% if loop.index0 < max_length %}
                     <li>{{ src }}</li>
-                  {% elif loop.index0 == max_length %}
-                    <li><a href="{{ project_url }}/lists/files.html"><em>All source files&hellip;</em></a></li>
                   {%- endif -%}
                 {%- endfor -%}
               </ul>
+            </div>
+            <div>
+              <ul>
+                <li><a href="{{ project_url }}/lists/files.html"><em>All source files&hellip;</em></a></li>
+              </ul>
+            </div>
           </div>
-        {% endif %}
+          {% endif %}
           {% if project.modules|length > 0 %}
-		  <div class="col-xs-6 col-sm-{{ width }}">
+          <div class="col-xs-6 col-sm-{{ width }}">
+            <div>
               <h3>Modules</h3>
               <ul>
                 {%- for mod in (project.modules|sort(attribute='name'))[:max_length] -%}
                   {% if loop.index0 < max_length %}
                     <li>{{ mod }}</li>
-                  {% elif loop.index0 == max_length %}
-                    <li><a href="{{ project_url }}/lists/modules.html"><em>All modules&hellip;</em></a></li>
                   {%- endif -%}
                 {%- endfor -%}
               </ul>
+            </div>
+            <div>
+              <ul>
+                <li><a href="{{ project_url }}/lists/modules.html"><em>All modules&hellip;</em></a></li>
+              </ul>
+            </div>
           </div>
           {% endif %}
           {% if project.procedures|length > 0 %}
-		  <div class="col-xs-6 col-sm-{{ width }}">
+          <div class="col-xs-6 col-sm-{{ width }}">
+            <div>
               <h3>Procedures</h3>
               <ul>
                 {%- for proc in (project.procedures|sort(attribute='name'))[:max_length] -%}
                   {% if loop.index0 < max_length %}
                     <li>{{ proc }}</li>
-                  {% elif loop.index0 == max_length %}
-                    <li><a href="{{ project_url }}/lists/procedures.html"><em>All procedures&hellip;</em></a></li>
                   {%- endif -%}
                 {%- endfor -%}
               </ul>
+            </div>
+            <div>
+              <ul>
+                <li><a href="{{ project_url }}/lists/procedures.html"><em>All procedures&hellip;</em></a></li>
+              </ul>
+            </div>
           </div>
           {% endif %}
           {% if project.types|length > 0 %}
-		  <div class="col-xs-6 col-sm-{{ width }}">
+          <div class="col-xs-6 col-sm-{{ width }}">
+            <div>
               <h3>Derived Types</h3>
               <ul>
                 {%- for dtype in (project.types|sort(attribute='name'))[:max_length] -%}
                   {% if loop.index0 < max_length %}
                     <li>{{ dtype }}</li>
-                  {% elif loop.index0 == max_length %}
-                    <li><a href="{{ project_url }}/lists/types.html"><em>All derived types&hellip;</em></a></li>
                   {%- endif -%}
                 {%- endfor -%}
               </ul>
+            </div>
+            <div>
+              <ul>
+                <li><a href="{{ project_url }}/lists/types.html"><em>All derived types&hellip;</em></a></li>
+              </ul>
+            </div>
           </div>
           {% endif %}
-      </div>
+        </div>
       {% endif %}
 {% endblock body %}
 


### PR DESCRIPTION
- Suppress frontpage section of files/modules/etc if max_frontpage_items=0 (headers were still displayed)
- Fix for not displaying the link to "All files/All modules/etc." below the `max_frontpage_items` items in each category

I haven't run the "Corpus regressions" workflow test on my branch ...