### PR TITLE
Add `show_proc_parent` option for graphs

### DIFF
--- a/docs/user_guide/project_file_options.rst
+++ b/docs/user_guide/project_file_options.rst
@@ -872,6 +872,15 @@ maximum or, if the even a depth of one would result in more nodes than
 the maximum, it will be restructured to give a clearer visualisation.
 (*default:* 100000000)
 
+.. _option-show_proc_parent:
+
+show_proc_parent
+^^^^^^^^^^^^^^^^
+
+If ``true`` then the parent module of a procedure will be displayed in
+the graphs as follows: parent::procedure. 
+(*default:* ``false``)
+
 Output
 ------
 

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -190,6 +190,7 @@ DEFAULT_SETTINGS = {
     "quiet": False,
     "revision": None,
     "search": True,
+    "show_proc_parent": False,
     "sort": "src",
     "source": False,
     "src_dir": ["./src"],

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -742,7 +742,7 @@ class FortranGraph:
         # add root nodes to the graph
         for n in sorted(self.root):
             if len(self.root) == 1:
-                self.dot.node(n.ident, label=n.name)
+                self.dot.node(n.ident, label=n.attribs["label"])
             else:
                 self.dot.node(n.ident, **n.attribs)
             self.added.add(n)

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -423,8 +423,8 @@ class ProcNode(BaseNode):
         super().__init__(obj, gd)
 
         if gd.show_proc_parent:
-            if hasattr(obj, "parent"):
-                self.attribs["label"] = obj.parent.name + "::" + self.name
+            if parent := getattr(obj, "parent", None):
+                self.attribs["label"] = f"{parent.name}::{self.name}"
 
         self.uses = set()
         self.calls = set()

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -131,10 +131,12 @@ class GraphData:
         Path to top of site
     coloured_edges:
         If true, arrows between nodes are coloured, otherwise they are black
+    show_proc_parent:
+        If true, the parent of a procedure is shown in the node label
 
     """
 
-    def __init__(self, parent_dir: str, coloured_edges: bool):
+    def __init__(self, parent_dir: str, coloured_edges: bool, show_proc_parent: bool):
         self.submodules: NodeCollection = {}
         self.modules: NodeCollection = {}
         self.types: NodeCollection = {}
@@ -144,6 +146,7 @@ class GraphData:
         self.blockdata: NodeCollection = {}
         self.parent_dir = parent_dir
         self.coloured_edges = coloured_edges
+        self.show_proc_parent = show_proc_parent
 
     def _get_collection_and_node_type(
         self, obj: FortranContainer
@@ -418,6 +421,11 @@ class ProcNode(BaseNode):
         # ToDo: Figure out appropriate way to handle interfaces to routines in submodules.
         self.proctype = getattr(obj, "proctype", "")
         super().__init__(obj, gd)
+
+        if gd.show_proc_parent:
+            if hasattr(obj, "parent"):
+                self.attribs["label"] = obj.parent.name + "::" + self.name
+
         self.uses = set()
         self.calls = set()
         self.called_by = set()
@@ -547,7 +555,7 @@ def _dashed_edge(tail, head, colour, label=None):
 if graphviz_installed:
     # Create the legends for the graphs. These are their own separate graphs,
     # without edges
-    gd = GraphData("", False)
+    gd = GraphData("", False, False)
 
     # Graph nodes for a bunch of fake entities that we'll use in the legend
     _module = gd.get_node(ExternalModule("Module"))
@@ -1225,6 +1233,9 @@ class GraphManager:
     coloured_edges:
         If true, arrows in graphs use different colours to help
         distinguish them
+    show_proc_parent:
+        If true, show the parent of a procedure in the call graph
+        as part of the label
     save_graphs:
         If true, save graphs as separate files, as well as embedding
         them in the HTML
@@ -1237,6 +1248,7 @@ class GraphManager:
         graphdir: os.PathLike,
         parentdir: str,
         coloured_edges: bool,
+        show_proc_parent: bool,
         save_graphs: bool = False,
     ):
         self.graph_objs: List[FortranContainer] = []
@@ -1252,7 +1264,7 @@ class GraphManager:
         self.typegraph = None
         self.callgraph = None
         self.filegraph = None
-        self.data = GraphData(parentdir, coloured_edges)
+        self.data = GraphData(parentdir, coloured_edges, show_proc_parent)
 
     def register(self, obj: FortranContainer):
         """Register ``obj`` as a node to be used in graphs"""

--- a/ford/output.py
+++ b/ford/output.py
@@ -140,6 +140,7 @@ class Documentation(object):
             self.data.get("graph_dir", ""),
             graphparent,
             self.data["coloured_edges"],
+            self.data["show_proc_parent"],
             save_graphs=bool(self.data.get("graph_dir", False)),
         )
 

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -98,7 +98,9 @@ def make_project_graphs(tmp_path_factory):
     settings["graph"] = True
     project = create_project(settings)
 
-    graphs = GraphManager("", "", graphdir="", parentdir="..", coloured_edges=True, show_proc_parent=False)
+    graphs = GraphManager(
+        "", "", graphdir="", parentdir="..", coloured_edges=True, show_proc_parent=True
+    )
     for entity_list in [
         project.types,
         project.procedures,
@@ -135,15 +137,15 @@ TYPE_GRAPH_KEY = ["Type"]
         (
             ["usegraph"],
             [
-                "module~a",
-                "module~b",
-                "module~c",
-                "module~c_submod",
-                "module~c_subsubmod",
+                "a",
+                "b",
+                "c",
+                "c_submod",
+                "c_subsubmod",
                 "iso_fortran_env",
                 "external_mod",
-                "proc~three",
-                "program~foo",
+                "foo::three",
+                "foo",
             ],
             [
                 "module~b->module~a",
@@ -159,14 +161,7 @@ TYPE_GRAPH_KEY = ["Type"]
         ),
         (
             ["callgraph"],
-            [
-                "proc~one",
-                "proc~three",
-                "proc~two",
-                "proc~four",
-                "other_sub",
-                "program~foo",
-            ],
+            ["c::one", "foo::three", "c::two", "foo::four", "other_sub", "foo"],
             [
                 "proc~three->proc~one",
                 "proc~three->proc~two",
@@ -179,7 +174,7 @@ TYPE_GRAPH_KEY = ["Type"]
         ),
         (
             ["typegraph"],
-            ["type~base", "type~derived", "type~leaf", "external_type", "type~thing"],
+            ["base", "derived", "leaf", "external_type", "thing"],
             [
                 "type~leaf->type~derived",
                 "type~derived->type~base",
@@ -190,19 +185,13 @@ TYPE_GRAPH_KEY = ["Type"]
         ),
         (
             ["modules", "b", "usesgraph"],
-            ["module~a", "module~b"],
+            ["a", "b"],
             ["module~b->module~a"],
             MOD_GRAPH_KEY,
         ),
         (
             ["modules", "b", "usedbygraph"],
-            [
-                "module~b",
-                "module~c",
-                "module~c_submod",
-                "module~c_subsubmod",
-                "program~foo",
-            ],
+            ["b", "c", "c_submod", "c_subsubmod", "foo"],
             [
                 "module~c->module~b",
                 "module~c_submod->module~c",
@@ -213,31 +202,31 @@ TYPE_GRAPH_KEY = ["Type"]
         ),
         (
             ["types", "derived", "inhergraph"],
-            ["type~base", "type~derived"],
+            ["base", "derived"],
             ["type~derived->type~base"],
             TYPE_GRAPH_KEY,
         ),
         (
             ["types", "derived", "inherbygraph"],
-            ["type~derived", "type~leaf", "type~thing"],
+            ["derived", "leaf", "thing"],
             ["type~leaf->type~derived", "type~thing->type~derived"],
             TYPE_GRAPH_KEY,
         ),
         (
             ["procedures", "two", "callsgraph"],
-            ["proc~one", "proc~two"],
+            ["c::one", "c::two"],
             ["proc~two->proc~one"],
             PROC_GRAPH_KEY,
         ),
         (
             ["procedures", "two", "calledbygraph"],
-            ["proc~three", "proc~two", "program~foo"],
+            ["foo::three", "c::two", "foo"],
             ["proc~three->proc~two", "program~foo->proc~three"],
             PROC_GRAPH_KEY,
         ),
         (
             ["procedures", "three", "usesgraph"],
-            ["external_mod", "proc~three"],
+            ["external_mod", "foo::three"],
             ["proc~three->external_mod"],
             MOD_GRAPH_KEY,
         ),
@@ -267,7 +256,7 @@ def test_graphs(
 
     soup = BeautifulSoup(str(graph), features="html.parser")
     # Get nodes and edges just in the graph, and not in the legend
-    node_names = [s.title.text for s in soup.svg.find_all("g", class_="node")]
+    node_names = [s.find("text").text for s in soup.svg.find_all("g", class_="node")]
     edge_names = [s.title.text for s in soup.svg.find_all("g", class_="edge")]
 
     assert sorted(node_names) == sorted(expected_nodes)

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -98,7 +98,7 @@ def make_project_graphs(tmp_path_factory):
     settings["graph"] = True
     project = create_project(settings)
 
-    graphs = GraphManager("", "", graphdir="", parentdir="..", coloured_edges=True)
+    graphs = GraphManager("", "", graphdir="", parentdir="..", coloured_edges=True, show_proc_parent=False)
     for entity_list in [
         project.types,
         project.procedures,


### PR DESCRIPTION
add an option to show the parent module of procedures in their graphs.

this adds the functionality mentioned in #364