### PR TITLE
add typebound procedures to call graph, and show the bound type on procedures' page

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -422,9 +422,15 @@ class ProcNode(BaseNode):
         self.proctype = getattr(obj, "proctype", "")
         super().__init__(obj, gd)
 
-        if gd.show_proc_parent:
-            if parent := getattr(obj, "parent", None):
-                self.attribs["label"] = f"{parent.name}::{self.name}"
+        if parent := getattr(obj, "parent", None):
+            parent_label = f"{parent.name}::"
+        else:
+            parent_label = ""
+        if binding := getattr(obj, "binding", None):
+            binding_label = f"{binding.parent.name}%"
+        else:
+            binding_label = ""
+        self.attribs["label"] = f"{parent_label}{binding_label}{self.name}"
 
         self.uses = set()
         self.calls = set()

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -581,10 +581,10 @@ class FortranContainer(FortranBase):
     )
     ARITH_GOTO_RE = re.compile(r"go\s*to\s*\([0-9,\s]+\)", re.IGNORECASE)
     CALL_RE = re.compile(
-        r"(?:^|[^a-zA-Z0-9_% ]\s*)(\w+)(?=\s*\(\s*(?:.*?)\s*\))", re.IGNORECASE
+        r"(?:^|[^a-zA-Z0-9_% ]\s*(?:\w+%)?)(\w+)(?=\s*\(\s*(?:.*?)\s*\))", re.IGNORECASE
     )
     SUBCALL_RE = re.compile(
-        r"^(?:if\s*\(.*\)\s*)?call\s+(\w+)\s*(?:\(\s*(.*?)\s*\))?$", re.IGNORECASE
+        r"^(?:if\s*\(.*\)\s*)?call\s+(?:\w+%)?(\w+)\s*(?:\(\s*(.*?)\s*\))?$", re.IGNORECASE
     )
     FORMAT_RE = re.compile(r"^[0-9]+\s+format\s+\(.*\)", re.IGNORECASE)
 
@@ -2253,6 +2253,7 @@ class FortranBoundProcedure(FortranBase):
             for i in range(len(self.bindings)):
                 if self.bindings[i].lower() in self.all_procs:
                     self.bindings[i] = self.all_procs[self.bindings[i].lower()]
+                    self.bindings[i].binding = self
                     break
             # else:
             #    self.bindings[i] = FortranSpoof(self.bindings[i], self.parent, 'BOUNDPROC')

--- a/ford/templates/proc_page.html
+++ b/ford/templates/proc_page.html
@@ -24,6 +24,11 @@
     {{ procedure.doc }}
     {% endif %}
 
+    {% if procedure.binding %}
+    <h3>Type Bound</h3>
+    <p>{{ procedure.binding.parent }}</p>
+    {% endif %}
+
     <h3>Arguments</h3>
     {% if procedure.args|length > 0 %}
       {{ macros.variable_list(procedure.args, intent=True) }}

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -55,12 +55,24 @@ def make_project_graphs(tmp_path_factory):
         type(derived) :: part
       end type thing
 
+      type alpha
+      contains
+        procedure :: five
+        procedure :: six
+      end type alpha
+
     contains
       subroutine one
       end subroutine one
       subroutine two
         call one
       end subroutine two
+      subroutine five
+      end subroutine five
+      function six(this) result(res)
+        real :: res
+        res = 1
+      end function six
     end module c
 
     submodule (c) c_submod
@@ -72,6 +84,10 @@ def make_project_graphs(tmp_path_factory):
     program foo
       use c
       call three
+      real :: x
+      type(alpha) :: y
+      call y%five()
+      x = y%six()
     contains
       subroutine three
         use external_mod
@@ -161,7 +177,7 @@ TYPE_GRAPH_KEY = ["Type"]
         ),
         (
             ["callgraph"],
-            ["c::one", "foo::three", "c::two", "foo::four", "other_sub", "foo"],
+            ["c::one", "foo::three", "c::two", "foo::four", "other_sub", "foo","c::alpha%five","c::alpha%six"],
             [
                 "proc~three->proc~one",
                 "proc~three->proc~two",
@@ -169,12 +185,14 @@ TYPE_GRAPH_KEY = ["Type"]
                 "proc~three->other_sub",
                 "program~foo->proc~three",
                 "proc~four->proc~four",
+                "program~foo->proc~five",
+                "program~foo->proc~six",
             ],
             PROC_GRAPH_KEY,
         ),
         (
             ["typegraph"],
-            ["base", "derived", "leaf", "external_type", "thing"],
+            ["base", "derived", "leaf", "external_type", "thing", "alpha"],
             [
                 "type~leaf->type~derived",
                 "type~derived->type~base",


### PR DESCRIPTION
this commit tackles the following todo stated in the wiki:
"Add the ability to identify type-bound procedure calls and use these when constructing call-trees"

Type bound function calls will now show up in the call graph as follows:
typename%procname

Additionally, on the doc page for any procedure that is bound to a type, an additional header is added for the type that is bound, and links to the type.