### PR TITLE
Fix `bind` names for subroutines, and pull out common base class for procedures

### DIFF
--- a/.github/workflows/corpus_regressions.yml
+++ b/.github/workflows/corpus_regressions.yml
@@ -1,7 +1,5 @@
 name: "Corpus regressions"
-on:
-  push:
-    branches: "master"
+on: pull_request
 
 jobs:
   regression:

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -49,14 +49,13 @@ from ford.sourceform import (
     ExternalType,
     FortranBlockData,
     FortranContainer,
-    FortranFunction,
     FortranInterface,
     FortranModule,
+    FortranProcedure,
     FortranProgram,
     FortranSourceFile,
     FortranSubmodule,
     FortranSubmoduleProcedure,
-    FortranSubroutine,
     FortranType,
 )
 
@@ -96,12 +95,7 @@ def is_type(obj):
 def is_proc(obj):
     return isinstance(
         obj,
-        (
-            FortranFunction,
-            FortranSubroutine,
-            FortranInterface,
-            FortranSubmoduleProcedure,
-        ),
+        (FortranProcedure, FortranInterface, FortranSubmoduleProcedure),
     )
 
 
@@ -230,7 +224,7 @@ class GraphData:
 
     def get_procedure_node(
         self,
-        procedure: Union[FortranSubroutine, FortranFunction, str],
+        procedure: Union[FortranProcedure, str],
         hist: NodeCollection,
     ) -> ProcNode:
         if isinstance(procedure, str):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1496,9 +1496,14 @@ class FortranProcedure(FortranCodeUnit):
             search_from += QUOTES_RE.search(self.bindC[search_from:]).end(0)
 
     @property
+    def interface_procedure(self) -> bool:
+        """Is this procedure just an interface?"""
+        return isinstance(self.parent, FortranInterface) and not self.parent.generic
+
+    @property
     def permission(self):
         """Permission (public/private) of this procedure"""
-        if isinstance(self.parent, FortranInterface) and not self.parent.generic:
+        if self.interface_procedure:
             return self.parent.permission
 
         return self._permission

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -134,17 +134,13 @@ class FortranBase(object):
         self.hierarchy.reverse()
 
     @property
-    def filename(self):
+    def filename(self) -> str:
         """Name of the file containing this entity"""
         # If `hierarchy` is empty, it's probably because it's a source
         # file, so we can use its name directly
         return self.hierarchy[0].name if self.hierarchy else self.name
 
-    def get_dir(self):
-        if isinstance(self, FortranProcedure) and self.is_interface_procedure:
-            return "interface"
-        if isinstance(self, FortranSubmodule):
-            return "module"
+    def get_dir(self) -> Optional[str]:
         if isinstance(
             self,
             (
@@ -1426,6 +1422,9 @@ class FortranSubmodule(FortranModule):
                 for proc in interface.iterator("subroutines", "functions"):
                     self.all_procs[proc.name.lower()] = proc
 
+    def get_dir(self):
+        return "module"
+
 
 def _list_of_procedure_attributes(attribute_string: str) -> Tuple[List[str], str]:
     """Convert a string of attributes into a list of attributes"""
@@ -1502,6 +1501,12 @@ class FortranProcedure(FortranCodeUnit):
         if self.is_interface_procedure:
             return namelist.get_name(self.parent)
         return super().ident
+
+    def get_dir(self) -> Optional[str]:
+        if self.is_interface_procedure:
+            return "interface"
+
+        return super().get_dir()
 
 
 class FortranSubroutine(FortranProcedure):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1495,6 +1495,18 @@ class FortranProcedure(FortranCodeUnit):
             )
             search_from += QUOTES_RE.search(self.bindC[search_from:]).end(0)
 
+    @property
+    def permission(self):
+        """Permission (public/private) of this procedure"""
+        if isinstance(self.parent, FortranInterface) and not self.parent.generic:
+            return self.parent.permission
+
+        return self._permission
+
+    @permission.setter
+    def permission(self, value):
+        self._permission = value
+
 
 class FortranSubroutine(FortranProcedure):
     """
@@ -1532,17 +1544,6 @@ class FortranSubroutine(FortranProcedure):
         self.attr_dict = defaultdict(list)
         self.param_dict = dict()
         self.associate_blocks = []
-
-    def set_permission(self, value):
-        self._permission = value
-
-    def get_permission(self):
-        if type(self.parent) == FortranInterface and not self.parent.generic:
-            return self.parent.permission
-        else:
-            return self._permission
-
-    permission = property(get_permission, set_permission)
 
     def _cleanup(self):
         self.all_procs = {}
@@ -1630,17 +1631,6 @@ class FortranFunction(FortranProcedure):
         self.attr_dict = defaultdict(list)
         self.param_dict = dict()
         self.associate_blocks = []
-
-    def set_permission(self, value):
-        self._permission = value
-
-    def get_permission(self):
-        if type(self.parent) == FortranInterface and not self.parent.generic:
-            return self.parent.permission
-        else:
-            return self._permission
-
-    permission = property(get_permission, set_permission)
 
     def _cleanup(self):
         self.all_procs = {}

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -571,7 +571,8 @@ class FortranContainer(FortranBase):
         r"(?:^|[^a-zA-Z0-9_% ]\s*(?:\w+%)?)(\w+)(?=\s*\(\s*(?:.*?)\s*\))", re.IGNORECASE
     )
     SUBCALL_RE = re.compile(
-        r"^(?:if\s*\(.*\)\s*)?call\s+(?:\w+%)?(\w+)\s*(?:\(\s*(.*?)\s*\))?$", re.IGNORECASE
+        r"^(?:if\s*\(.*\)\s*)?call\s+(?:\w+%)?(\w+)\s*(?:\(\s*(.*?)\s*\))?$",
+        re.IGNORECASE,
     )
     FORMAT_RE = re.compile(r"^[0-9]+\s+format\s+\(.*\)", re.IGNORECASE)
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -141,7 +141,7 @@ class FortranBase(object):
         return self.hierarchy[0].name if self.hierarchy else self.name
 
     def get_dir(self):
-        if isinstance(self, FortranProcedure) and self.interface_procedure:
+        if isinstance(self, FortranProcedure) and self.is_interface_procedure:
             return "interface"
         if isinstance(self, FortranSubmodule):
             return "module"
@@ -1480,14 +1480,14 @@ class FortranProcedure(FortranCodeUnit):
             search_from += QUOTES_RE.search(self.bindC[search_from:]).end(0)
 
     @property
-    def interface_procedure(self) -> bool:
+    def is_interface_procedure(self) -> bool:
         """Is this procedure just an interface?"""
         return isinstance(self.parent, FortranInterface) and not self.parent.generic
 
     @property
     def permission(self):
         """Permission (public/private) of this procedure"""
-        if self.interface_procedure:
+        if self.is_interface_procedure:
             return self.parent.permission
 
         return self._permission
@@ -1499,7 +1499,7 @@ class FortranProcedure(FortranCodeUnit):
     @property
     def ident(self) -> str:
         """Return a unique identifier for this object"""
-        if self.interface_procedure:
+        if self.is_interface_procedure:
             return namelist.get_name(self.parent)
         return super().ident
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -233,12 +233,6 @@ class FortranBase(object):
     @property
     def ident(self) -> str:
         """Return a unique identifier for this object"""
-        if (
-            isinstance(self, (FortranSubroutine, FortranFunction))
-            and isinstance(self.parent, FortranInterface)
-            and not self.parent.generic
-        ):
-            return namelist.get_name(self.parent)
         return namelist.get_name(self)
 
     @property
@@ -1511,6 +1505,13 @@ class FortranProcedure(FortranCodeUnit):
     @permission.setter
     def permission(self, value):
         self._permission = value
+
+    @property
+    def ident(self) -> str:
+        """Return a unique identifier for this object"""
+        if self.interface_procedure:
+            return namelist.get_name(self.parent)
+        return super().ident
 
 
 class FortranSubroutine(FortranProcedure):

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -177,7 +177,16 @@ TYPE_GRAPH_KEY = ["Type"]
         ),
         (
             ["callgraph"],
-            ["c::one", "foo::three", "c::two", "foo::four", "other_sub", "foo","c::alpha%five","c::alpha%six"],
+            [
+                "c::one",
+                "foo::three",
+                "c::two",
+                "foo::four",
+                "other_sub",
+                "foo",
+                "c::alpha%five",
+                "c::alpha%six",
+            ],
             [
                 "proc~three->proc~one",
                 "proc~three->proc~two",

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1527,3 +1527,27 @@ def test_function_whitespace(parse_fortran_file):
     function = fortran_file.functions[0]
     arg_names = [arg.name for arg in function.args]
     assert arg_names == ["a", "b", "c", "d"]
+
+
+def test_bind_name_subroutine(parse_fortran_file):
+    data = """\
+    subroutine init() bind(C, name="c_init")
+    end subroutine init
+    """
+
+    fortran_file = parse_fortran_file(data)
+    subroutine = fortran_file.subroutines[0]
+
+    assert subroutine.bindC == 'C, name="c_init"'
+
+
+def test_bind_name_function(parse_fortran_file):
+    data = """\
+    integer function foo() bind(C, name="c_foo")
+    end function foo
+    """
+
+    fortran_file = parse_fortran_file(data)
+    function = fortran_file.functions[0]
+
+    assert function.bindC == 'C, name="c_foo"'

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -738,13 +738,15 @@ def test_submodule_ancestors(parse_fortran_file):
             "procedure(bar) :: thing",
             ParsedType("procedure", ":: thing", proto=["bar", ""]),
         ),
+        ("Vec :: vector", ParsedType("vec", ":: vector")),
+        ("Mat :: matrix", ParsedType("mat", ":: matrix")),
     ],
 )
 def test_parse_type(variable_decl, expected):
     # Tokeniser will have previously replaced strings with index into
     # this list
     capture_strings = ['"a"']
-    result = parse_type(variable_decl, capture_strings, {"extra_vartypes": []})
+    result = parse_type(variable_decl, capture_strings, ["Vec", "Mat"])
     assert result.vartype == expected.vartype
     assert result.kind == expected.kind
     assert result.strlen == expected.strlen


### PR DESCRIPTION
Fixes #506 

Pull out a common `FortranProcedure` base class for subroutines and functions. Allows removing a lot of duplicated code shared between the two, as well as being able to generically check for procedures using `isinstance`