### PR TITLE
fix internal procedure's calls not showing up in call graphs

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -431,6 +431,7 @@ class ProcNode(BaseNode):
         self.called_by = set()
         self.interfaces = set()
         self.interfaced_by = set()
+        self.internal = getattr(obj, 'parobj', None) == 'proc'
 
         if self.fromstr:
             return
@@ -1155,6 +1156,8 @@ class CallGraph(FortranGraph):
             if p not in hop_nodes:
                 hop_nodes.add(p)
             hop_edges.append(_solid_edge(node, p, colour))
+            if p.internal:
+                self._add_node(hop_nodes, hop_edges, p, colour)
         for p in sorted(getattr(node, "interfaces", [])):
             if p not in hop_nodes:
                 hop_nodes.add(p)

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -31,6 +31,7 @@ from urllib.request import urlopen, URLError
 from urllib.parse import urljoin
 import pathlib
 from typing import Union
+import itertools
 
 
 NOTE_TYPE = {
@@ -548,3 +549,12 @@ def normalise_path(
 ) -> pathlib.Path:
     """Tidy up path, making it absolute, relative to base_dir"""
     return (base_dir / os.path.expandvars(path)).absolute()
+
+def traverse(root, attrs) -> list:
+    """Traverse a tree of objects, returning a list of all objects found
+    within the attributes attrs"""
+    nodes = []
+    for obj in itertools.chain(*[getattr(root, attr, []) for attr in attrs]):
+        nodes.append(obj)
+        nodes.extend(traverse(obj, attrs))
+    return nodes


### PR DESCRIPTION
procedures that are internal to a procedure will now show their calls in call graphs.