### PR TITLE
Add procedure binding calls to call graph

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1105,9 +1105,19 @@ class FortranCodeUnit(FortranContainer):
                     and call.name not in getattr(context, "all_types", {})
                     and call.name not in all_vars
                 ):
-                    # if can't find the call in context, add it as a string
-                    call = context.all_procs.get(call.name, call.name)
-                    tmplst.append(call)
+                    if call.chain == []:
+                        # if can't find the call in context, add it as a string
+                        tmplst.append(context.all_procs.get(call.name, call.name))
+                    # if the call is made from a type, then it must be a bound procedure
+                    else:
+                        for bound in context.boundprocs:
+                            if call.name == bound.name.lower():
+                                tmplst.append(bound)
+                                break
+                        else:
+                            # failed to find the call in context, add it as a string
+                            tmplst.append(call.name)
+                                    
 
             self.calls = tmplst
 

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -60,6 +60,9 @@ def make_project_graphs(tmp_path_factory, request):
       contains
         procedure :: five
         procedure :: six
+        procedure :: ei => eight
+        procedure :: ni => nine
+        generic :: eight_nine => ei, ni
       end type alpha
 
     contains
@@ -85,6 +88,14 @@ def make_project_graphs(tmp_path_factory, request):
             call one
           end subroutine seven_two
       end subroutine seven
+      subroutine eight(this,x)
+        class(alpha) :: this
+        real :: x
+      end subroutine eight
+      subroutine nine(this,x)
+        class(alpha) :: this
+        integer :: x
+      end subroutine nine
     end module c
 
     submodule (c) c_submod
@@ -100,6 +111,8 @@ def make_project_graphs(tmp_path_factory, request):
       type(alpha) :: y
       call y%five()
       x = y%six()
+      call y%ei(1.0)
+      call y%eight_nine(1.0)
     contains
       subroutine three
         use external_mod
@@ -214,6 +227,9 @@ TYPE_GRAPH_KEY = ["Type"]
                 "c::alpha%five",
                 "c::alpha%six",
                 "c::seven",
+                "c::alpha%eight",
+                "c::alpha%nine",
+                "c::alpha%eight_nine",
             ],
             [
                 "proc~three->proc~one",
@@ -225,6 +241,10 @@ TYPE_GRAPH_KEY = ["Type"]
                 "program~foo->proc~five",
                 "program~foo->proc~six",
                 "proc~seven->proc~one",
+                "program~foo->proc~eight",
+                "program~foo->none~eight_nine",
+                "none~eight_nine->proc~eight",
+                "none~eight_nine->proc~nine",
             ],
             PROC_GRAPH_KEY,
         ),
@@ -243,6 +263,9 @@ TYPE_GRAPH_KEY = ["Type"]
                 "c::seven",
                 "seven::seven_one",
                 "seven::seven_two",
+                "c::alpha%eight",
+                "c::alpha%nine",
+                "c::alpha%eight_nine",
             ],
             [
                 "proc~three->proc~one",
@@ -257,6 +280,10 @@ TYPE_GRAPH_KEY = ["Type"]
                 "proc~seven->none~seven_two",
                 "none~seven_one->none~seven_two",
                 "none~seven_two->proc~one",
+                "program~foo->proc~eight",
+                "program~foo->none~eight_nine",
+                "none~eight_nine->proc~eight",
+                "none~eight_nine->proc~nine",
             ],
             PROC_GRAPH_KEY,
         ),


### PR DESCRIPTION
This allows for call graphs to properly pick up on more complex bindings calls by comparing the calls to the bindings of a type rather then procedures that are in the type's context. This allows for bindings that may rename a proc to be properly recognized (i.e. procedure :: new_name => original_proc_name).

Some bindings are generic bindings that map one name onto multiple procs. To handle this, bindings can now be nodes themselves in the call graphs. At the moment, I made their color the same as interfaces, and calls made from them with dotted lines.
Here is a basic example:
```
type :: some_type
contains
  procedure :: one
  procedure :: two
  generic :: one_two => one, two
end type some_type
```
![example](https://github.com/Fortran-FOSS-Programmers/ford/assets/40001404/b405e9e9-f85e-4d24-802a-be6d48301b1b)

'Simple' bindings that are just one label pointing to one proc are skipped over in the call graph, as I though it cluttered up the graph and was redundant.

This solves issue #516
