### PR TITLE
Fix call chain parsing for some edge cases

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -453,7 +453,7 @@ class ProcNode(BaseNode):
                 n = gd.get_procedure_node(c, hist)
                 n.called_by.add(self)
                 self.calls.add(n)
-            elif getattr(c, 'parobj', None) == 'proc' and c not in seen:
+            elif getattr(c, "parobj", None) == "proc" and c not in seen:
                 calls.extend(getattr(c, "calls", []))
                 seen[c] = True
 
@@ -1320,9 +1320,11 @@ class GraphManager:
                 obj.calledbygraph = CalledByGraph(obj, self.data)
                 obj.usesgraph = UsesGraph(obj, self.data)
                 self.procedures.add(obj)
-                # regester internal procedures 
-                for p in ford.utils.traverse(obj, ["subroutines","functions"]):
-                    self.internal_procedures.add(p) if getattr(p, "visible", False) else None
+                # regester internal procedures
+                for p in ford.utils.traverse(obj, ["subroutines", "functions"]):
+                    self.internal_procedures.add(p) if getattr(
+                        p, "visible", False
+                    ) else None
             elif is_program(obj):
                 obj.usesgraph = UsesGraph(obj, self.data)
                 obj.callsgraph = CallsGraph(obj, self.data)

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -98,7 +98,12 @@ def is_type(obj):
 def is_proc(obj):
     return isinstance(
         obj,
-        (FortranProcedure, FortranInterface, FortranSubmoduleProcedure, FortranBoundProcedure),
+        (
+            FortranProcedure,
+            FortranInterface,
+            FortranSubmoduleProcedure,
+            FortranBoundProcedure,
+        ),
     )
 
 
@@ -248,21 +253,21 @@ class GraphData:
 
 
 def get_call_nodes(calls, visited=None, result=None):
-    '''
+    """
     takes a list of calls, and returns a set of all the calls that should
     be nodes in the graph
 
-    not all calls are a node, some are not visible, and some are simple 
+    not all calls are a node, some are not visible, and some are simple
     procedure bindings (bindings that bind one procedure to one label)
 
     these should be skipped, and show a call to their descendant instead
-    '''
-    
+    """
+
     if visited is None:
         visited = set()
     if result is None:
         result = set()
-    
+
     for call in calls:
         # ensure we haven't already visited this call
         if call in visited:
@@ -270,11 +275,13 @@ def get_call_nodes(calls, visited=None, result=None):
         visited.add(call)
 
         # value for if the call is a simple binding
-        is_simple_binding = (isinstance(call, FortranBoundProcedure) 
-                            and len(call.bindings) == 1 
-                            and not isinstance(call.bindings[0], FortranBoundProcedure))
+        is_simple_binding = (
+            isinstance(call, FortranBoundProcedure)
+            and len(call.bindings) == 1
+            and not isinstance(call.bindings[0], FortranBoundProcedure)
+        )
 
-        if getattr(call,"visible",True) and not is_simple_binding:
+        if getattr(call, "visible", True) and not is_simple_binding:
             # If the call is visible and isn't a simple binding, add it to the result.
             result.add(call)
         else:
@@ -446,7 +453,12 @@ class TypeNode(BaseNode):
 
 
 class ProcNode(BaseNode):
-    COLOURS = {"subroutine": "#d9534f", "function": "#d94e8f", "interface": "#A7506F", "boundproc": "#A7506F"}
+    COLOURS = {
+        "subroutine": "#d9534f",
+        "function": "#d94e8f",
+        "interface": "#A7506F",
+        "boundproc": "#A7506F",
+    }
 
     @property
     def colour(self):
@@ -490,8 +502,10 @@ class ProcNode(BaseNode):
             n = gd.get_module_node(u)
             n.used_by.add(self)
             self.uses.add(n)
-        
-        for call in get_call_nodes(getattr(obj, "calls", []) + getattr(obj, "bindings", [])):
+
+        for call in get_call_nodes(
+            getattr(obj, "calls", []) + getattr(obj, "bindings", [])
+        ):
             n = gd.get_procedure_node(call, hist)
             n.called_by.add(self)
             self.calls.add(n)
@@ -1200,7 +1214,7 @@ class CallGraph(FortranGraph):
         for p in sorted(node.calls):
             if p not in hop_nodes:
                 hop_nodes.add(p)
-            if getattr(node,"proctype","") != "boundproc":
+            if getattr(node, "proctype", "") != "boundproc":
                 hop_edges.append(_solid_edge(node, p, colour))
             else:
                 hop_edges.append(_dashed_edge(node, p, colour))
@@ -1225,7 +1239,7 @@ class CallsGraph(FortranGraph):
         for p in sorted(node.calls):
             if p not in self.added:
                 hop_nodes.add(p)
-            if getattr(node,"proctype","") != "boundproc":
+            if getattr(node, "proctype", "") != "boundproc":
                 hop_edges.append(_solid_edge(node, p, colour))
             else:
                 hop_edges.append(_dashed_edge(node, p, colour))
@@ -1360,8 +1374,11 @@ class GraphManager:
                 obj.inherbygraph = InheritedByGraph(obj, self.data)
                 self.types.add(obj)
                 # register bound procedures that arn't simple bindings (bindings that bind one procedure to one label)
-                for bp in getattr(obj,"boundprocs",[]):
-                    if not (len(bp.bindings) == 1 and not isinstance(bp.bindings[0], FortranBoundProcedure)):
+                for bp in getattr(obj, "boundprocs", []):
+                    if not (
+                        len(bp.bindings) == 1
+                        and not isinstance(bp.bindings[0], FortranBoundProcedure)
+                    ):
                         self.bound_procedures.add(bp)
             elif is_proc(obj):
                 obj.callsgraph = CallsGraph(obj, self.data)
@@ -1386,7 +1403,9 @@ class GraphManager:
                 self.blockdata.add(obj)
 
         usenodes = sorted(list(self.modules))
-        callnodes = sorted(list(self.procedures | self.internal_procedures | self.bound_procedures))
+        callnodes = sorted(
+            list(self.procedures | self.internal_procedures | self.bound_procedures)
+        )
         for p in sorted(self.programs):
             if len(p.usesgraph.added) > 1:
                 usenodes.append(p)

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2909,12 +2909,13 @@ class CallChain:
     chain: List[str]
 
 def get_call_chain(line, match) -> CallChain:
-    sub_line = line[:match.start(1)].lower()
+    sub_line = line[:match.start(1)].lower().rstrip()
     if len(sub_line) == 0 or sub_line[-1] != "%":
         # not a chain call
         return CallChain(match.group(1).lower(), [])
     level = sub_line.count("(") - sub_line.count(")")
-    sub_line = ford.utils.strip_paren(sub_line, retlevel=level, index = len(sub_line) - 1)
+    blevel = sub_line.count("[") - sub_line.count("]")
+    sub_line = ford.utils.strip_paren(sub_line, retlevel=level, retblevel=blevel, index = len(sub_line) - 1)
     # remove 'call ' from the start if present
     sub_line = sub_line[5:] if sub_line.startswith("call ") else sub_line
     # get end of sub_line after last non-alphanumeric character

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -581,8 +581,13 @@ class FortranContainer(FortranBase):
         r"(?:^|[^a-zA-Z0-9_ ]\s*)(\w+)(?=\s*\(\s*(?:.*?)\s*\))", re.IGNORECASE
     )
     SUBCALL_RE = re.compile(
-        r"^(?:if\s*\(.*\)\s*)?call\s+(?:\w+%)*(\w+)\s*(?:\(\s*(.*?)\s*\))?$",
-        re.IGNORECASE,
+        r"""^(?:if\s*\(.*\)\s*)?               # Optional 'if' statement
+        call\s+                                # Required keyword
+        (?:\s*\w+\s*%\s*)*                     # Optional type component access
+        (?P<name>\w+)                          # Required subroutine name
+        \s*(?:\(\s*(?P<arguments>.*?)\s*\))?$  # Optional arguments
+        """,
+        re.IGNORECASE | re.VERBOSE,
     )
     FORMAT_RE = re.compile(r"^[0-9]+\s+format\s+\(.*\)", re.IGNORECASE)
 

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -119,19 +119,20 @@ def get_parens(line: str, retlevel: int = 0, retblevel: int = 0) -> str:
         return parenstr
     raise RuntimeError("Couldn't parse parentheses: {}".format(line))
 
-def strip_paren(line: str, retlevel: int = 0, retblevel: int = 0, index = -1) -> str:
+
+def strip_paren(line: str, retlevel: int = 0, retblevel: int = 0, index=-1) -> str:
     """
     Takes a string with parentheses and returns only the portion of the string
     that is in the same level of nested parentheses as specified by retlevel.
     If index is specified, then characters in the same level but not in the same
-    scope as the char at index are also stripped. 
+    scope as the char at index are also stripped.
     """
     if len(line) == 0:
         return line
     retstr = StringIO()
     level = 0
     blevel = 0
-    for i,char in enumerate(line):
+    for i, char in enumerate(line):
         if char == "(":
             level += 1
         elif char == ")":
@@ -140,13 +141,10 @@ def strip_paren(line: str, retlevel: int = 0, retblevel: int = 0, index = -1) ->
             blevel += 1
         elif char == "]":
             blevel -= 1
-        elif (
-            level == retlevel
-            and blevel == retblevel
-        ):
+        elif level == retlevel and blevel == retblevel:
             retstr.write(char)
-        
-        if index >= 0 and char == ')' and level < retlevel:
+
+        if index >= 0 and char == ")" and level < retlevel:
             # scope of index is yet to start, reset retstr
             if i < index:
                 retstr = StringIO()
@@ -155,6 +153,7 @@ def strip_paren(line: str, retlevel: int = 0, retblevel: int = 0, index = -1) ->
                 return retstr.getvalue()
 
     return retstr.getvalue()
+
 
 def paren_split(sep, string):
     """
@@ -584,6 +583,7 @@ def normalise_path(
 ) -> pathlib.Path:
     """Tidy up path, making it absolute, relative to base_dir"""
     return (base_dir / os.path.expandvars(path)).absolute()
+
 
 def traverse(root, attrs) -> list:
     """Traverse a tree of objects, returning a list of all objects found

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -26,7 +26,10 @@ def create_project(settings: dict):
     project.correlate()
     return project
 
+
 project_graphs = {}
+
+
 @pytest.fixture(scope="module")
 def make_project_graphs(tmp_path_factory, request):
     data = """\
@@ -115,8 +118,15 @@ def make_project_graphs(tmp_path_factory, request):
     end program foo
     """
     # check if we've already created the graphs for this test
-    if "proc_internals_" + str(getattr(request, 'param', {}).get('proc_internals', False)) in project_graphs:
-        yield project_graphs["proc_internals_" + str(getattr(request, 'param', {}).get('proc_internals', False))]
+    if (
+        "proc_internals_"
+        + str(getattr(request, "param", {}).get("proc_internals", False))
+        in project_graphs
+    ):
+        yield project_graphs[
+            "proc_internals_"
+            + str(getattr(request, "param", {}).get("proc_internals", False))
+        ]
         return
 
     src_dir = tmp_path_factory.getbasetemp() / "graphs" / "src"
@@ -128,7 +138,7 @@ def make_project_graphs(tmp_path_factory, request):
     settings = deepcopy(DEFAULT_SETTINGS)
     settings["src_dir"] = [src_dir]
     settings["graph"] = True
-    if 'proc_internals' in getattr(request, 'param', {}):
+    if "proc_internals" in getattr(request, "param", {}):
         settings["proc_internals"] = request.param["proc_internals"]
 
     project = create_project(settings)
@@ -153,8 +163,11 @@ def make_project_graphs(tmp_path_factory, request):
     graphs.output_graphs(0)
 
     # save graphs for future use
-    project_graphs["proc_internals_" + str(getattr(request, 'param', {}).get('proc_internals', False))] = graphs
-    
+    project_graphs[
+        "proc_internals_"
+        + str(getattr(request, "param", {}).get("proc_internals", False))
+    ] = graphs
+
     yield graphs
     # reset namelist so it doesn't affect future generated graphs
     ford.sourceform.namelist = ford.sourceform.NameSelector()
@@ -173,10 +186,16 @@ TYPE_GRAPH_KEY = ["Type"]
 
 @pytest.mark.skipif(not graphviz_installed, reason="Requires graphviz")
 @pytest.mark.parametrize(
-    ("make_project_graphs","graph_name", "expected_nodes", "expected_edges", "expected_legend_nodes"),
+    (
+        "make_project_graphs",
+        "graph_name",
+        "expected_nodes",
+        "expected_edges",
+        "expected_legend_nodes",
+    ),
     [
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["usegraph"],
             [
                 "a",
@@ -202,7 +221,7 @@ TYPE_GRAPH_KEY = ["Type"]
             MOD_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["callgraph"],
             [
                 "c::one",
@@ -229,7 +248,7 @@ TYPE_GRAPH_KEY = ["Type"]
             PROC_GRAPH_KEY,
         ),
         (
-            {"proc_internals":True},
+            {"proc_internals": True},
             ["callgraph"],
             [
                 "c::one",
@@ -261,7 +280,7 @@ TYPE_GRAPH_KEY = ["Type"]
             PROC_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["typegraph"],
             ["base", "derived", "leaf", "external_type", "thing", "alpha"],
             [
@@ -273,14 +292,14 @@ TYPE_GRAPH_KEY = ["Type"]
             TYPE_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["modules", "b", "usesgraph"],
             ["a", "b"],
             ["module~b->module~a"],
             MOD_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["modules", "b", "usedbygraph"],
             ["b", "c", "c_submod", "c_subsubmod", "foo"],
             [
@@ -292,54 +311,54 @@ TYPE_GRAPH_KEY = ["Type"]
             MOD_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["types", "derived", "inhergraph"],
             ["base", "derived"],
             ["type~derived->type~base"],
             TYPE_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["types", "derived", "inherbygraph"],
             ["derived", "leaf", "thing"],
             ["type~leaf->type~derived", "type~thing->type~derived"],
             TYPE_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["procedures", "two", "callsgraph"],
             ["c::one", "c::two"],
             ["proc~two->proc~one"],
             PROC_GRAPH_KEY,
         ),
         (
-            {"proc_internals":True},
+            {"proc_internals": True},
             ["procedures", "seven", "callsgraph"],
             ["c::seven", "c::one", "seven::seven_one", "seven::seven_two"],
             [
-                "proc~seven->none~seven_one", 
-                "proc~seven->none~seven_two", 
-                "none~seven_one->none~seven_two", 
+                "proc~seven->none~seven_one",
+                "proc~seven->none~seven_two",
+                "none~seven_one->none~seven_two",
                 "none~seven_two->proc~one",
             ],
             PROC_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["procedures", "two", "calledbygraph"],
             ["foo::three", "c::two", "foo"],
             ["proc~three->proc~two", "program~foo->proc~three"],
             PROC_GRAPH_KEY,
         ),
         (
-            {"proc_internals":False},
+            {"proc_internals": False},
             ["procedures", "three", "usesgraph"],
             ["external_mod", "foo::three"],
             ["proc~three->external_mod"],
             MOD_GRAPH_KEY,
         ),
     ],
-    indirect=["make_project_graphs"]
+    indirect=["make_project_graphs"],
 )
 def test_graphs(
     make_project_graphs,

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -313,7 +313,7 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
 def test_type_chain_function_and_subroutine_calls(
     parse_fortran_file, call_segment, expected
 ):
-    data = """\
+    data = f"""\
     MODULE m_foo
         IMPLICIT NONE
         TYPE :: t_baz
@@ -350,16 +350,11 @@ def test_type_chain_function_and_subroutine_calls(
         END SUBROUTINE p_bar
 
         SUBROUTINE main
-            ! Call segment
-            {}
-            ! Call segment
+            {call_segment}
         END SUBROUTINE main
 
     END MODULE m_foo
-
-    """.format(
-        call_segment
-    )
+    """
 
     fortran_file = parse_fortran_file(data)
     fp = FakeProject()

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -234,63 +234,85 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
     expected_calls = {"bar", "foo"}
     assert set([call.name for call in program.calls]) == expected_calls
 
+
 @pytest.mark.parametrize(
     ["call_segment", "expected"],
     [
-        ("""
-        TYPE(t_bar) :: v_bar
-        TYPE(t_baz) :: var
-        var = v_bar%p_foo()
-        """
-        , ["p_foo"]),
-        ("""
-        TYPE(t_bar) :: v_bar
-        INTEGER :: var
-        var = v_bar%v_foo(0)
-        """
-        , []),
-        ("""
-        TYPE(t_bar) :: v_bar
-        INTEGER :: var
-        var = [v_bar%v_foo(0)]
-        """
-        , []),
-        ("""
-        TYPE(t_bar) :: v_bar
-        INTEGER, DIMENSION(:), ALLOCATABLE :: var
-        var = v_bar%v_baz%p_baz()
-        """
-        , ["p_baz"]),
-        ("""
-        TYPE(t_bar) :: v_bar
-        TYPE(t_baz) :: var
-        var = v_bar%t_foo%p_foo()
-        """
-        , ["p_foo"]),
-        ("""
-        TYPE(t_bar) :: v_bar
-        TYPE(t_baz) :: var(1)
-        var = [v_bar%t_foo%p_foo()]
-        """
-        , ["p_foo"]),
-        ("""
-        TYPE(t_bar) :: v_bar
-        INTEGER :: var
-        var = v_bar%v_baz%v_faz(0)
-        """
-        , []),
-        ("""
-        TYPE(t_bar) :: v_bar
-        call v_bar % p_bar ( )
-        """
-        , ["p_bar"]),
-        ("""
-        TYPE(t_bar) :: v_bar
-        call v_bar % p_bar ( v_bar % v_baz % p_baz () )
-        """
-        , ["p_bar", "p_baz"]), 
-   ])
-def test_type_chain_function_and_subroutine_calls(parse_fortran_file,call_segment, expected):
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            TYPE(t_baz) :: var
+            var = v_bar%p_foo()
+            """,
+            ["p_foo"],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            INTEGER :: var
+            var = v_bar%v_foo(0)
+            """,
+            [],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            INTEGER :: var
+            var = [v_bar%v_foo(0)]
+            """,
+            [],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            INTEGER, DIMENSION(:), ALLOCATABLE :: var
+            var = v_bar%v_baz%p_baz()
+            """,
+            ["p_baz"],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            TYPE(t_baz) :: var
+            var = v_bar%t_foo%p_foo()
+            """,
+            ["p_foo"],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            TYPE(t_baz) :: var(1)
+            var = [v_bar%t_foo%p_foo()]
+            """,
+            ["p_foo"],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            INTEGER :: var
+            var = v_bar%v_baz%v_faz(0)
+            """,
+            [],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            call v_bar % p_bar ( )
+            """,
+            ["p_bar"],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
+            call v_bar % p_bar ( v_bar % v_baz % p_baz () )
+            """,
+            ["p_bar", "p_baz"],
+        ),
+    ],
+)
+def test_type_chain_function_and_subroutine_calls(
+    parse_fortran_file, call_segment, expected
+):
     data = """\
     MODULE m_foo
         IMPLICIT NONE
@@ -299,7 +321,7 @@ def test_type_chain_function_and_subroutine_calls(parse_fortran_file,call_segmen
         CONTAINS
             PROCEDURE :: p_baz
         END TYPE t_baz
-            
+
         TYPE :: t_foo
             INTEGER, DIMENSION(:), ALLOCATABLE :: v_foo
         CONTAINS
@@ -311,7 +333,7 @@ def test_type_chain_function_and_subroutine_calls(parse_fortran_file,call_segmen
         CONTAINS
             PROCEDURE :: p_bar
         END TYPE t_bar
-        
+
         CONTAINS
 
         FUNCTION p_baz(self) RESULT(ret_val)
@@ -335,7 +357,9 @@ def test_type_chain_function_and_subroutine_calls(parse_fortran_file,call_segmen
 
     END MODULE m_foo
 
-    """.format(call_segment)
+    """.format(
+        call_segment
+    )
 
     fortran_file = parse_fortran_file(data)
     fp = FakeProject()

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -251,6 +251,12 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
         , []),
         ("""
         TYPE(t_bar) :: v_bar
+        INTEGER :: var
+        var = [v_bar%v_foo(0)]
+        """
+        , []),
+        ("""
+        TYPE(t_bar) :: v_bar
         INTEGER, DIMENSION(:), ALLOCATABLE :: var
         var = v_bar%v_baz%p_baz()
         """
@@ -259,6 +265,12 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
         TYPE(t_bar) :: v_bar
         TYPE(t_baz) :: var
         var = v_bar%t_foo%p_foo()
+        """
+        , ["p_foo"]),
+        ("""
+        TYPE(t_bar) :: v_bar
+        TYPE(t_baz) :: var(1)
+        var = [v_bar%t_foo%p_foo()]
         """
         , ["p_foo"]),
         ("""

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -297,6 +297,13 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
         (
             """
             TYPE(t_bar) :: v_bar
+            call v_bar%renamed()
+            """,
+            ["renamed"],
+        ),
+        (
+            """
+            TYPE(t_bar) :: v_bar
             call v_bar % p_bar ( )
             """,
             ["p_bar"],
@@ -332,6 +339,7 @@ def test_type_chain_function_and_subroutine_calls(
             TYPE(t_baz) :: v_baz
         CONTAINS
             PROCEDURE :: p_bar
+            PROCEDURE :: renamed => p_bar
         END TYPE t_bar
 
         CONTAINS

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -284,7 +284,12 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
         call v_bar % p_bar ( )
         """
         , ["p_bar"]),
-    ])
+        ("""
+        TYPE(t_bar) :: v_bar
+        call v_bar % p_bar ( v_bar % v_baz % p_baz () )
+        """
+        , ["p_bar", "p_baz"]), 
+   ])
 def test_type_chain_function_and_subroutine_calls(parse_fortran_file,call_segment, expected):
     data = """\
     MODULE m_foo

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -41,14 +41,18 @@ def test_str_to_bool_already_bool():
     assert ford.utils.str_to_bool(True)
     assert not ford.utils.str_to_bool(False)
 
-@pytest.mark.parametrize(("string", "level", "index", "expected"),
-                            [("abcdefghi", 0, -1, "abcdefghi"),
-                             ("abc(def)ghi", 1, -1, "def"),
-                             ("abc(def)ghi", 0, -1, "abcghi"),
-                             ("(abc)def(ghi)", 1, 1, "abc"),
-                             ("(abc)def(ghi)", 1, 9, "ghi"),
-                             ("(abc)def(ghi)", 1, -1, "abcghi"),
-                             ("(a(b)c)def(gh(i))", 1, 2, "ac"),
-                            ])
+
+@pytest.mark.parametrize(
+    ("string", "level", "index", "expected"),
+    [
+        ("abcdefghi", 0, -1, "abcdefghi"),
+        ("abc(def)ghi", 1, -1, "def"),
+        ("abc(def)ghi", 0, -1, "abcghi"),
+        ("(abc)def(ghi)", 1, 1, "abc"),
+        ("(abc)def(ghi)", 1, 9, "ghi"),
+        ("(abc)def(ghi)", 1, -1, "abcghi"),
+        ("(a(b)c)def(gh(i))", 1, 2, "ac"),
+    ],
+)
 def test_strip_paren(string, level, index, expected):
-    assert ford.utils.strip_paren(string, retlevel = level, index = index) == expected
+    assert ford.utils.strip_paren(string, retlevel=level, index=index) == expected


### PR DESCRIPTION
Fixes some cases where the parsing of call chain fails.
Specifically if there is white-space tailing the last % in the chain,
and if the call is made inside of square brackets.