### PR TITLE
Try to give a more helpful error message when parsing has failed

### DIFF
--- a/ford/output.py
+++ b/ford/output.py
@@ -51,7 +51,25 @@ def is_more_than_one(collection):
     return collection > 1
 
 
+def meta(entity, item):
+    """Get item from entity's meta dict, but give a more helpful
+    error message if entity doesn't have a meta attribute
+
+    Hopefully gives a better error than the common "RuntimeError: 'str
+    object' has no attribute 'meta'"
+
+    """
+    if not hasattr(entity, "meta"):
+        return jinja2.StrictUndefined(
+            f"Unknown entity '{entity}': This likely means an error in parsing, "
+            "please check that this file compiles with a Fortran compiler"
+        )
+
+    return entity.meta.get(item, None)
+
+
 env.tests["more_than_one"] = is_more_than_one
+env.filters["meta"] = meta
 
 USER_WRITABLE_ONLY = 0o755
 
@@ -286,7 +304,9 @@ class BasePage:
             return self.render(self.data, self.proj, self.obj)
         except Exception as e:
             raise RuntimeError(
-                f"Error rendering '{self.outfile.name}' for '{self.obj.name}' : {e}"
+                f"Error rendering '{self.outfile.name}':\n"
+                f'  File "{self.obj.filename}": {self.obj.obj} "{self.obj.name}"\n'
+                f"    {e}"
             )
 
     def writeout(self):

--- a/ford/templates/absint_list.html
+++ b/ford/templates/absint_list.html
@@ -11,7 +11,7 @@ All Abstract Interfaces &ndash; {{ project }}
 			 <tr><th>Abstract Interface</th><th>Location</th><th>Description</th></tr>
 			 </thead><tbody>
 			 {% for absint in project.absinterfaces|sort(attribute='name') %}
-			   <tr><td>{{ absint }}</td><td>{{ absint.parent }}</td><td>{{ absint.procedure.meta['summary'] }}</td></tr>
+			   <tr><td>{{ absint }}</td><td>{{ absint.parent }}</td><td>{{ absint.procedure | meta('summary') }}</td></tr>
 			 {% endfor %}
 			 </tbody></table>
         </div>

--- a/ford/templates/block_list.html
+++ b/ford/templates/block_list.html
@@ -10,7 +10,7 @@ All Block Data Units &ndash; {{ project }}
 			 <thead><tr><th>Block Data Unit</th><th>Source File</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for block in project.blockdata|sort(attribute='name') %}
-			   <tr><td>{{ block }}</td><td>{{ block.parent }}</td><td>{{ block.meta['summary'] }}</td></tr>
+			   <tr><td>{{ block }}</td><td>{{ block.parent }}</td><td>{{ block | meta('summary') }}</td></tr>
 			 {% endfor %}
 			 </tbody></table>
         </div>

--- a/ford/templates/file_list.html
+++ b/ford/templates/file_list.html
@@ -10,7 +10,7 @@ All Files &ndash; {{ project }}
 			 <thead><tr><th>File</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for src in project.allfiles|sort(attribute='name') %}
-			   <tr><td>{{ src }}</td><td>{{ src.meta['summary'] }}</td></tr>
+			   <tr><td>{{ src }}</td><td>{{ src | meta('summary') }}</td></tr>
 			 {% endfor %}
 			 </tbody></table>
 			 {{ project.filegraph }}

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -3,31 +3,31 @@
     <div class="col-lg-12">
       <div class="well well-sm">
         <ul class="list-inline" style="margin-bottom:0px;display:inline">
-          {% if entity.meta['author'] %}
-            <li id="meta-author"><i class="fa fa-pencil"></i> {{ entity.meta['author'] }}</li>
+          {% if entity | meta('author') %}
+            <li id="meta-author"><i class="fa fa-pencil"></i> {{ entity | meta('author') }}</li>
           {% endif %}
-          {% if entity.meta['date'] %}
-            <li id="meta-date"><i class="fa fa-calendar-o"></i> {{ entity.meta['date'] }}</li>
+          {% if entity | meta('date') %}
+            <li id="meta-date"><i class="fa fa-calendar-o"></i> {{ entity | meta('date') }}</li>
           {% endif %}
-          {% if entity.meta['license'] %}
-            <li id="meta-license"><i class="fa fa-legal"></i> {{ entity.meta['license'] }}</li>
+          {% if entity | meta('license') %}
+            <li id="meta-license"><i class="fa fa-legal"></i> {{ entity | meta('license') }}</li>
           {% elif projectData['license'] %}
             <li id="meta-license"><i class="fa fa-legal"></i> {{ projectData['license'] }}</li>
           {% endif %}
-          {% if entity.meta['since'] %}
-            <li id="meta-since"><i class="fa fa-history"></i> Since: {{ entity.meta['since'] }}</li>
+          {% if entity | meta('since') %}
+            <li id="meta-since"><i class="fa fa-history"></i> Since: {{ entity | meta('since') }}</li>
           {% endif %}
-          {% if entity.meta['version'] %}
-            <li id="meta-version"><i class="fa fa-barcode"></i> {{ entity.meta['version'] }}</li>
+          {% if entity | meta('version') %}
+            <li id="meta-version"><i class="fa fa-barcode"></i> {{ entity | meta('version') }}</li>
           {% endif %}
-          {% if entity.meta['category'] %}
-            <li id="meta-category"><i class="fa fa-folder-open"></i> {{ entity.meta['category'] }}</li>
+          {% if entity | meta('category') %}
+            <li id="meta-category"><i class="fa fa-folder-open"></i> {{ entity | meta('category') }}</li>
           {% endif %}
 
           <li id="statements"><i class="fa fa-list-ol"></i>
             <a data-toggle="tooltip"
                data-placement="bottom" data-html="true"
-               title="{{ line_info }}">{{ entity.meta['num_lines'] }} statements</a>
+               title="{{ line_info }}">{{ entity | meta('num_lines') }} statements</a>
           </li>
 
           {% if incl_src %}
@@ -153,7 +153,7 @@
 
 {% macro deprecated(entity) %}
   {# Add 'Deprecated' warning #}
-  {%- if entity.meta['deprecated'] -%}
+  {%- if entity | meta('deprecated') -%}
     <span class="label label-danger depwarn">Deprecated</span>
   {%- endif -%}
 {% endmacro %}
@@ -208,7 +208,7 @@
             {% endif %}
             <td>
               {% if summary -%}
-                {{ var.meta['summary'] }}
+                {{ var | meta('summary') }}
               {% else %}
                 {{ var.doc }}
               {% endif %}
@@ -245,7 +245,7 @@
   {%- if full_docstring or not entity.visible -%}
     {{ entity.doc }}
   {%- else -%}
-    {{ entity.meta["summary"] }}
+    {{ entity | meta("summary") }}
   {%- endif -%}
 {%- endmacro -%}
 
@@ -344,7 +344,7 @@
                 {% if not bind.visible %}
                   {{ meta_list(bind.meta) }}
                 {% endif %}
-                {{ bind.meta['summary'] }}
+                {{ bind | meta('summary') }}
               {% endif %}
               {{ binding_summary(bind.procedure) }}
             {% else %}
@@ -411,7 +411,7 @@
     {% if intr.doc or meta_list(intr.meta)|trim %}
       <div class="panel-body">
         {{ meta_list(intr.meta) }}
-        {{ intr.meta['summary'] }}
+        {{ intr | meta('summary') }}
       </div>
     {% endif %}
     <ul class="list-group">
@@ -481,7 +481,7 @@
       {% if not dtype.visible %}
         {{ meta_list(dtype.meta) }}
       {% endif %}
-      {{ dtype.meta['summary'] }}
+      {{ dtype | meta('summary') }}
 
       {% if dtype.variables %}
         <h4>Components</h4>
@@ -526,7 +526,7 @@
             {% for fin in dtype.finalprocs %}
               <tr>
                 <td>final :: <strong>{{ fin.name }}</strong></td>
-                <td>{{ fin.meta['summary'] }}</td>
+                <td>{{ fin | meta('summary') }}</td>
               </tr>
             {% endfor %}
           </tbody>
@@ -557,7 +557,7 @@
                   {% endif %}
                   {% if tb.bindings|length == 1 %}<small>{{ tb.bindings[0].proctype }}</small>{% endif %}
                 </td>
-                <td>{{ tb.meta['summary'] }}</td>
+                <td>{{ tb | meta('summary') }}</td>
               </tr>
               {% endfor %}
           </tbody>
@@ -598,7 +598,7 @@
           {% for var in enum.variables %}
             <tr>
               <td>{{ var.vartype }}</td><td>::</td>
-              <td><strong>{{ var.name }}</strong></td><td> = </td><td>{{ var.initial }}</td><td>{% if summary -%}{{ var.meta['summary'] }}{% else %}{{ var.doc }}{% endif %}</td>
+              <td><strong>{{ var.name }}</strong></td><td> = </td><td>{{ var.initial }}</td><td>{% if summary -%}{{ var | meta('summary') }}{% else %}{{ var.doc }}{% endif %}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/ford/templates/proc_list.html
+++ b/ford/templates/proc_list.html
@@ -10,7 +10,7 @@ All Procedures &ndash; {{ project }}
 			 <thead><tr><th>Procedure</th><th>Location</th><th>Procedure Type</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for proc in project.procedures|sort(attribute='name') %}
-			   <tr><td>{{ proc }}</td><td>{{ proc.parent }}</td><td>{{ proc.proctype }}</td><td>{{ proc.meta['summary'] }}</td></tr>
+			   <tr><td>{{ proc }}</td><td>{{ proc.parent }}</td><td>{{ proc.proctype }}</td><td>{{ proc | meta('summary') }}</td></tr>
 			 {% endfor %}
 			 </tbody></table>
              {{ project.callgraph }}

--- a/ford/templates/prog_list.html
+++ b/ford/templates/prog_list.html
@@ -10,7 +10,7 @@ All Programs &ndash; {{ project }}
 			 <thead><tr><th>Program</th><th>Source File</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for prog in project.programs|sort(attribute='name') %}
-			   <tr><td>{{ prog }}</td><td>{{ prog.parent }}</td><td>{{ prog.meta['summary'] }}</td></tr>
+			   <tr><td>{{ prog }}</td><td>{{ prog.parent }}</td><td>{{ prog | meta('summary') }}</td></tr>
 			 {% endfor %}
 			 </tbody></table>
         </div>


### PR DESCRIPTION
If we've not managed to catch the error during parsing, ford will often fail when trying to render the output page with a cryptic:

      RuntimeError: 'str object' has no attribute 'meta'

This tries to be a bit more helpful and guide the user to the likely source of the error (which might still be due to a bug in ford)