### PR TITLE
Adding HTML escaping of initial values

### DIFF
--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -200,7 +200,7 @@
             {% if not intent %}
               {% if var.initial -%}
                 <td>{% if var.points -%} =&gt; {% else %} = {%- endif %}</td>
-                <td>{{ var.initial }}</td>
+                <td>{{ var.initial|e }}</td>
               {% else %}
                 <td></td>
                 <td></td>


### PR DESCRIPTION
If Fortran parameters contain HTML/XML, their initial values are not properly escaped. This pull request adds an escape filter to the macro template.