### PR TITLE
Fix call chains

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -578,9 +578,8 @@ class FortranContainer(FortranBase):
     )
     ARITH_GOTO_RE = re.compile(r"go\s*to\s*\([0-9,\s]+\)", re.IGNORECASE)
     CALL_RE = re.compile(
-        r"""(?:^|[^a-zA-Z0-9_ ]\s*)
-        (?P<parent>(?:\s*\w+\s*(?:\(\))?\s*%\s*)+)? # Optional type component access
-        (?P<name>\w+\s*\(.*?\))                     # Required function name
+        r"""(?P<parent>(?:\s*\w+\s*(?:\(\))?\s*%\s*)+)? # Optional type component access
+        (?P<name>\w+\s*\(.*?\))                         # Required function name
         """,
         re.IGNORECASE | re.VERBOSE,
     )

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -120,39 +120,37 @@ def get_parens(line: str, retlevel: int = 0, retblevel: int = 0) -> str:
     raise RuntimeError("Couldn't parse parentheses: {}".format(line))
 
 
-def strip_paren(line: str, retlevel: int = 0, retblevel: int = 0, index=-1) -> str:
+def strip_paren(line: str, retlevel: int = 0) -> list:
     """
-    Takes a string with parentheses and returns only the portion of the string
-    that is in the same level of nested parentheses as specified by retlevel.
-    If index is specified, then characters in the same level but not in the same
-    scope as the char at index are also stripped.
+    Takes a string with parentheses and removes any of the contents inside or outside
+    of the retlevel of parentheses. Additionally, whenever a scope of the retlevel is
+    left, the string is split.
+
+    e.g. strip_paren("foo(bar(quz) + faz) + baz(buz(cas))", 1) -> ["(bar() + faz)", "(buz())"]
     """
-    if len(line) == 0:
-        return line
-    retstr = StringIO()
+    retstrs = []
+    curstr = StringIO()
     level = 0
-    blevel = 0
-    for i, char in enumerate(line):
+    for char in line:
         if char == "(":
+            if level == retlevel or level + 1 == retlevel:
+                curstr.write(char)
             level += 1
         elif char == ")":
+            if level == retlevel or level - 1 == retlevel:
+                curstr.write(char)
+            if level == retlevel:
+                # We are leaving a scope of the desired level,
+                # and should split to indicate as such.
+                retstrs.append(curstr.getvalue())
+                curstr = StringIO()
             level -= 1
-        elif char == "[":
-            blevel += 1
-        elif char == "]":
-            blevel -= 1
-        elif level == retlevel and blevel == retblevel:
-            retstr.write(char)
+        elif level == retlevel:
+            curstr.write(char)
 
-        if index >= 0 and char == ")" and level < retlevel:
-            # scope of index is yet to start, reset retstr
-            if i < index:
-                retstr = StringIO()
-            # scope of index is over, return retstr
-            else:
-                return retstr.getvalue()
-
-    return retstr.getvalue()
+    if curstr.getvalue() != "":
+        retstrs.append(curstr.getvalue())
+    return retstrs
 
 
 def paren_split(sep, string):

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -349,6 +349,15 @@ def test_function_and_subroutine_call_on_same_line(parse_fortran_file):
             """,
             ["p_baz", "p_buz"],
         ),
+        (
+            """
+            USE m_foo, ONLY: t_baz
+
+            TYPE(t_baz) :: var_baz
+            write(*,*) var_baz%p_baz()
+            """,
+            ["p_baz"],
+        ),
     ],
 )
 def test_type_chain_function_and_subroutine_calls(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -43,16 +43,14 @@ def test_str_to_bool_already_bool():
 
 
 @pytest.mark.parametrize(
-    ("string", "level", "index", "expected"),
+    ("string", "level", "expected"),
     [
-        ("abcdefghi", 0, -1, "abcdefghi"),
-        ("abc(def)ghi", 1, -1, "def"),
-        ("abc(def)ghi", 0, -1, "abcghi"),
-        ("(abc)def(ghi)", 1, 1, "abc"),
-        ("(abc)def(ghi)", 1, 9, "ghi"),
-        ("(abc)def(ghi)", 1, -1, "abcghi"),
-        ("(a(b)c)def(gh(i))", 1, 2, "ac"),
+        ("abcdefghi", 0, ["abcdefghi"]),
+        ("abc(def)ghi", 1, ["(def)"]),
+        ("abc(def)ghi", 0, ["abc()ghi"]),
+        ("(abc)def(ghi)", 1, ["(abc)", "(ghi)"]),
+        ("(a(b)c)def(gh(i))", 1, ["(a()c)", "(gh())"]),
     ],
 )
-def test_strip_paren(string, level, index, expected):
-    assert ford.utils.strip_paren(string, retlevel=level, index=index) == expected
+def test_strip_paren(string, level, expected):
+    assert ford.utils.strip_paren(string, retlevel=level) == expected


### PR DESCRIPTION
@ZedThree , the refactor for the call chains parsing looks good, however, I've found a few issues with it that somehow made it past the tests. I've updated the tests to be more rigorous now, and should catch these issues now.

One issue was that the 'parent' group wasn't getting properly picked up when there were () in the call chain (for example when indexing into an array). Unfortunately I don't think this can't be done with regex alone because it requires bracket matching.

Another issue along the same vain was with the 'arguments' group for a subcall also not always being correct because of bracket matching.

To fix these issues, the contents of the parentheses are first striped prior to applying the regex. Then each layer of parentheses are stripped checked for matches. Additionally, I've moved the subcall section into the call section sense both can exist on the same line, and both get stored to self.calls anyways.