### PR TITLE
Fix missing labels on codeunits

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -204,7 +204,11 @@ class Project:
 
         def get_deps(item):
             uselist = [m[0] for m in item.uses]
-            for procedure in item.routines:
+            interfaceprocs = []
+            for intr in getattr(item, "interfaces", []):
+                if hasattr(intr, "procedure"):
+                    interfaceprocs.append(intr.procedure)
+            for procedure in chain(item.routines, interfaceprocs):
                 uselist.extend(get_deps(procedure))
             return uselist
 
@@ -398,3 +402,13 @@ def find_used_modules(
     # Find the modules that this entity's procedures use
     for procedure in entity.routines:
         find_used_modules(procedure, modules, submodules, external_modules)
+
+    # Find the modules that this entity's interfaces' procedures use
+    for interface in getattr(entity, "interfaces", []):
+        if hasattr(interface, "procedure"):
+            find_used_modules(
+                interface.procedure, modules, submodules, external_modules
+            )
+        else:
+            for procedure in interface.routines:
+                find_used_modules(procedure, modules, submodules, external_modules)

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1083,6 +1083,19 @@ class FortranCodeUnit(FortranContainer):
                         if hasattr(intr.procedure, "retvar"):
                             proc.retvar = intr.procedure.retvar
                         proc.proctype = intr.procedure.proctype
+                # Some module procs are from procedures implemented withen a generic interface
+                elif getattr(getattr(intr, "parent", None), "generic", False):
+                    baseproc = intr
+
+                    proc.module = baseproc
+                    baseproc.module = proc
+
+                    if isinstance(proc, FortranModuleProcedureImplementation):
+                        proc.attribs = baseproc.attribs
+                        proc.args = baseproc.args
+                        if hasattr(baseproc, "retvar"):
+                            proc.retvar = baseproc.retvar
+                        proc.proctype = baseproc.proctype
 
         def should_be_public(name: str) -> bool:
             """Is name public?"""

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1,6 +1,7 @@
 from ford.fortran_project import Project
 from ford import DEFAULT_SETTINGS
 from ford.utils import normalise_path
+from ford.sourceform import FortranVariable
 
 from copy import deepcopy
 from itertools import chain
@@ -676,6 +677,36 @@ def test_imported_abstract_interface_type_name(copy_fortran_file):
     project = create_project(settings)
     proto_names = [var.proto[0].name for var in project.modules[1].variables]
     assert proto_names == ["hello", "hello", "goodbye", "goodbye"]
+
+
+def test_generic_interface_inherited_attrs(copy_fortran_file):
+    data = """\
+    module module1
+      implicit none
+      interface routine
+        module subroutine routine_1(var)
+          integer, dimension(:) :: var
+        end subroutine routine_1
+      end interface
+      public :: routine
+    end module module1
+
+    submodule(module1) module2
+      implicit none
+    contains
+      module procedure routine_1
+      end procedure
+    end submodule module2
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+
+    module_implementation = project.modules[0].all_procs["routine_1"].module
+    # Check that the module implementation has been linked
+    assert not isinstance(module_implementation, bool)
+    # Check that mod proc has the inherited arg
+    assert isinstance(module_implementation.args[0], FortranVariable)
 
 
 def test_display_internal_procedures(copy_fortran_file):

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -421,6 +421,38 @@ def test_module_use_everything_reexport(copy_fortran_file):
     }
 
 
+def test_use_within_interface(copy_fortran_file):
+    data = """\
+    module module1
+      implicit none
+      private
+      interface
+        subroutine routine_1()
+          use module2, only: routine_2
+        end subroutine routine_1
+      end interface
+      public :: routine
+    end module module1
+
+    module module2
+      implicit none
+      private
+      public :: routine_2
+    contains
+      subroutine routine_2(i)
+        integer,intent(in) :: i
+        write(*,*) i
+      end subroutine routine_2
+    end module module2
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+    assert set(
+        project.modules[0].all_procs["routine_1"].procedure.all_procs.keys()
+    ) == {"routine_1", "routine_2"}
+
+
 def test_member_in_other_module(copy_fortran_file):
     data = """\
     module module1

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -449,9 +449,7 @@ def test_use_within_interface(copy_fortran_file):
 
     settings = copy_fortran_file(data)
     project = create_project(settings)
-    assert set(
-        project.modules[0].all_procs["routine_1"].procedure.all_procs.keys()
-    ) == {"routine_1", "routine_2"}
+    assert "routine_2" in project.modules[0].all_procs["routine_1"].procedure.all_procs
 
 
 def test_member_in_other_module(copy_fortran_file):

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -537,7 +537,6 @@ def test_submodule_private_var_call(parse_fortran_file):
       end procedure bar
     end submodule baz
     """
-    expected = []
 
     fortran_file = parse_fortran_file(data)
     fp = FakeProject()
@@ -555,14 +554,7 @@ def test_submodule_private_var_call(parse_fortran_file):
     main_subroutines = {sub.name: sub for sub in modules["baz"].modprocedures}
     calls = main_subroutines["bar"].calls
 
-    assert len(calls) == len(expected)
-
-    calls_sorted = sorted(calls, key=lambda x: getattr(x, "name", x))
-    expected_sorted = sorted(expected)
-    for call, expected_name in zip(calls_sorted, expected_sorted):
-        assert isinstance(call, FortranBase)
-
-        assert call.name == expected_name
+    assert calls == []
 
 
 def test_internal_proc_arg_var_call(parse_fortran_file):
@@ -583,7 +575,6 @@ def test_internal_proc_arg_var_call(parse_fortran_file):
       end subroutine bar
     end module foo
     """
-    expected = []
 
     fortran_file = parse_fortran_file(data)
     fp = FakeProject()
@@ -596,14 +587,7 @@ def test_internal_proc_arg_var_call(parse_fortran_file):
 
     calls = modules["foo"].subroutines[0].subroutines[0].calls
 
-    assert len(calls) == len(expected)
-
-    calls_sorted = sorted(calls, key=lambda x: getattr(x, "name", x))
-    expected_sorted = sorted(expected)
-    for call, expected_name in zip(calls_sorted, expected_sorted):
-        assert isinstance(call, FortranBase)
-
-        assert call.name == expected_name
+    assert calls == []
 
 
 def test_component_access(parse_fortran_file):


### PR DESCRIPTION
There were a few cases where some labels (e.g. vars, proc names) are missing from contexts that they should be present in.

Here are the cases that this PR fixes:

in submodules, the parent module's private vars
in internal procedures, the parent procedure's args and return values
in interfaces, imported items via USE
in generic interfaces implementation, the attributes of the base interface