### PR TITLE
Fix some tests for Windows

### DIFF
--- a/test/test_example.py
+++ b/test/test_example.py
@@ -6,6 +6,7 @@ import re
 from urllib.parse import urlparse
 
 import ford
+from ford.graphs import graphviz_installed
 
 from bs4 import BeautifulSoup
 import pytest
@@ -231,6 +232,7 @@ def test_types_finaliser(example_project):
     assert "More documentation" in finaliser_section.ul.text
 
 
+@pytest.mark.skipif(not graphviz_installed, reason="Requires graphviz")
 def test_graph_submodule(example_project):
     path, _ = example_project
     index = read_html(path / "module/test_submodule.html")

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -7,6 +7,10 @@ import pytest
 from conftest import gfortran_is_not_installed
 
 
+class FakeFile:
+    name = "test file"
+
+
 def test_quiet_false():
     """This checks that bool options like 'quiet' are parsed correctly in input md file"""
 
@@ -113,15 +117,17 @@ def test_no_preprocessor():
 
 
 def test_bad_preprocessor():
-    class FakeFile:
-        name = "test file"
-
     with pytest.raises(SystemExit):
         ford.parse_arguments({"project_file": FakeFile()}, "preprocessor: false")
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="FIXME: Need portable do-nothing command"
+)
 def test_maybe_ok_preprocessor():
-    data, _, _ = ford.parse_arguments({}, "preprocessor: true")
+    data, _, _ = ford.parse_arguments(
+        {"project_file": FakeFile()}, "preprocessor: true"
+    )
 
     if data["preprocess"] is True:
         assert isinstance(data["preprocessor"], list)

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -1,5 +1,6 @@
 import ford
 from textwrap import dedent
+from pathlib import Path
 import sys
 import pytest
 
@@ -50,10 +51,10 @@ def test_path_normalisation():
              src2
     """
     data, _, _ = ford.parse_arguments({}, dedent(settings), "/prefix/path")
-    assert str(data["page_dir"]) == "/prefix/path/my_pages"
+    assert str(data["page_dir"]) == str(Path("/prefix/path/my_pages"))
     assert [str(p) for p in data["src_dir"]] == [
-        "/prefix/path/src1",
-        "/prefix/path/src2",
+        str(Path("/prefix/path/src1")),
+        str(Path("/prefix/path/src2")),
     ]
 
 

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -1,4 +1,5 @@
 import pathlib
+import os.path
 import re
 import sys
 from typing import List
@@ -109,14 +110,15 @@ def test_default_aliases(
 
     html_dir = tmp_path / "doc"
     index_text = get_main_body_text(html_dir, "index.html")
+    media_dir = os.path.join(".", "media")
     expected_index_text = [
-        "Test: The project media url should be ./media",
+        f"Test: The project media url should be {media_dir}",
     ]
     assert index_text == expected_index_text
 
     module_text = get_main_body_text(html_dir, "module/test.html")
     expected_module_text = [
-        "Test: The project media url (./media) should work here too"
+        f"Test: The project media url ({media_dir}) should work here too"
     ]
     assert module_text == expected_module_text
 

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -2,7 +2,7 @@ import pathlib
 import os.path
 import re
 import sys
-from typing import List
+from typing import List, Optional
 
 import ford
 import ford.fortran_project
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 DEFAULT_SRC = "src"
 
 
-def run_ford(monkeypatch, md_file: pathlib.Path, extra_args: list = None):
+def run_ford(monkeypatch, md_file: pathlib.Path, extra_args: Optional[list] = None):
     """Modify command line args with argv"""
     with monkeypatch.context() as m:
         command = ["ford", str(md_file)]


### PR DESCRIPTION
- One example test requires graphviz, so that should be conditionally skipped
- Some tests were checking path normalisation explicitly in POSIX format, so result in different plain text on Windows
- One test runs `true /dev/null` as a trial preprocessor, but this will fail on Windows. I'm not sure of a better solution myself, so just skip this on Windows

I'm not sure that the path normalisation tests are doing the correct thing -- we probably actually want to always use URL formatting of paths (see #515 for some discussion)