### PR TITLE
Fix some issues in docs

### DIFF
--- a/docs/user_guide/documentation_meta_data.rst
+++ b/docs/user_guide/documentation_meta_data.rst
@@ -6,7 +6,7 @@
 
 When documenting your source files you can provide metadata at the top
 of an item’s documentation. Metadata is specified in the same way as in
-the [[project file|Project File Options]]. There can not be any other
+the :ref:`sec-project-options`. There can not be any other
 documentation before it; not even a blank line of documentation. This
 will work::
 

--- a/docs/user_guide/documentation_meta_data.rst
+++ b/docs/user_guide/documentation_meta_data.rst
@@ -4,8 +4,8 @@
  Documentation Metadata
 ========================
 
-When documenting your source files you can provide meta-data at the top
-of an item’s documentation. Meta-data is specified in the same way as in
+When documenting your source files you can provide metadata at the top
+of an item’s documentation. Metadata is specified in the same way as in
 the [[project file|Project File Options]]. There can not be any other
 documentation before it; not even a blank line of documentation. This
 will work::
@@ -27,7 +27,7 @@ but this won’t::
      !!
      !! This data-type represents a cat.
 
-The meta-data will be displayed for procedures, derived types, files,
+The metadata will be displayed for procedures, derived types, files,
 programs, modules, type-bound procedures, and interfaces. It may be
 displayed in more cases in future.
 

--- a/docs/user_guide/documentation_meta_data.rst
+++ b/docs/user_guide/documentation_meta_data.rst
@@ -1,3 +1,5 @@
+.. _sec-doc-metadata:
+
 ========================
  Documentation Metadata
 ========================
@@ -27,7 +29,14 @@ but this won’t::
 
 The meta-data will be displayed for procedures, derived types, files,
 programs, modules, type-bound procedures, and interfaces. It may be
-displayed in more cases in future. Recognized types of meta-data are:
+displayed in more cases in future.
+
+Metadata keys are letters, numbers, underscores, and dashes followed
+by a colon. Please also note that anything that *looks* like metadata
+will be parsed as such and so won't appear in the rendered
+documentation.
+
+Recognized types of metadata are:
 
 .. _metadata-author:
 

--- a/docs/user_guide/project_file_options.rst
+++ b/docs/user_guide/project_file_options.rst
@@ -5,12 +5,12 @@
 ======================
 
 You can specify various options and information for your project in the
-meta-data of your project file. Quoting from the `Markdown
+metadata of your project file. Quoting from the `Markdown
 Meta-Data <https://python-markdown.github.io/extensions/meta_data/>`__
-page (and not intending to give an example of the meta-data fields
+page (and not intending to give an example of the metadata fields
 supported by FORD):
 
-Meta-data consists of a series of keywords and values defined at the
+Metadata consists of a series of keywords and values defined at the
 beginning of a markdown document like this:
 
 .. code:: text
@@ -35,8 +35,8 @@ an additional line of the value for the previous keyword. A keyword
 may have as many lines as desired (note that these **must** be
 spaces and not tabs).
 
-The first blank line ends all meta-data for the document. Therefore,
-the first line of a document must not be blank. All meta-data is
+The first blank line ends all metadata for the document. Therefore,
+the first line of a document must not be blank. All metadata is
 stripped from the document prior to any further processing by
 Markdown.
 
@@ -51,7 +51,7 @@ the project file.
 *N.B.!*: Markdown comments must not appear within the meta data section!
 Typical markdown commenting strategies may be used within the markdown
 body of the project file, BUT NOT WITHIN THE META-DATA SECTION! After
-declaring meta-data HTML block comments of the form
+declaring metadata HTML block comments of the form
 
 .. code:: html
 
@@ -67,7 +67,7 @@ or markdown phony link comments may be used:
 
    [comment 1 goes here, this will declare a phony link target. Just make sure not to reference the null anchor]:#
 
-The options which can be specified in the meta-data are listed below.
+The options which can be specified in the metadata are listed below.
 Defaults are included in the description, if they exist.
 
 Project Information

--- a/docs/user_guide/running_ford.rst
+++ b/docs/user_guide/running_ford.rst
@@ -5,9 +5,9 @@
 Once you have written a project file which you’re satisfied with, it is
 time to run FORD. The most basic syntax for running ford is just
 
-::
+.. code:: console
 
-   ford project-file.md
+   $ ford project-file.md
 
 More advanced `command line options <sec-command-line-options>` are
 available. Assuming that there are no errors, your documentation will

--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -172,7 +172,7 @@ syntax ``{!file-name.md!}`` in any of your documentation will be
 replaced by the contents of file-name.md. This will be the first thing
 done when processing Markdown, and thus all Markdown syntax within
 file-name.md will be processed correctly. You can nest these include
-statments as many times as you like. All file paths are evaluated
+statements as many times as you like. All file paths are evaluated
 relative to the directory containing the project file, unless set to
 do otherwise.
 

--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -126,8 +126,8 @@ in your documentation and
 `Meta-Data <https://pythonhosted.org/Markdown/extensions/meta_data.html>`__.
 The latter is used internally as a way for the user to provide extra
 information to and/or customize the behaviour of FORD (see
-[[Documentation Meta-Data]]). Information on providing meta-data and
-what types of data FORD will look for can be found in the next section.
+:ref:`_sec-doc-metadata`). Information on providing metadata and what
+types of data FORD will look for can be found in the next section.
 
 LaTeX Support
 -------------

--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -100,10 +100,8 @@ support legacy code.
 
 By default, FORD will preprocess any files with extensions ``.F90``,
 ``.F95``, ``.F03``, ``.F08``, ``.F15``, ``.F``, or ``.FOR`` prior to
-parsing them for documentation. This behaviour can `be
-disabled <option-preprocess>`
-or `different
-extensions <option-fpp_extensions>`
+parsing them for documentation. This behaviour can `be disabled
+<option-preprocess>` or `different extensions <option-fpp_extensions>`
 can be specified, if desired. Note that any syntax-highlighted source
 code which is displayed in the output will be shown in its
 non-preprocessed form. The default preprocessor is CPP in legacy mode
@@ -114,20 +112,19 @@ Markdown
 --------
 
 All documentation, both that provided within the source files and that
-given in the project file, should be written in
-`Markdown <http://daringfireball.net/projects/markdown/syntax>`__. In
+given in the project file, should be written in `Markdown`_. In
 addition to the standard Markdown syntax, you can use all of the
-features in Python’s `Markdown
-Extra <https://pythonhosted.org/Markdown/extensions/extra.html>`__.
-Other Markdown extensions automatically loaded are
-`CodeHilite <https://pythonhosted.org/Markdown/extensions/code_hilite.html>`__
-which will provide syntax highlighting for any code fragments you place
-in your documentation and
-`Meta-Data <https://pythonhosted.org/Markdown/extensions/meta_data.html>`__.
-The latter is used internally as a way for the user to provide extra
-information to and/or customize the behaviour of FORD (see
-:ref:`_sec-doc-metadata`). Information on providing metadata and what
-types of data FORD will look for can be found in the next section.
+features in Python’s `Markdown Extra`_. Other Markdown extensions
+automatically loaded are `CodeHilite`_, which provides syntax
+highlighting for code fragments in your documentation, and
+`Meta-Data`_, which is used as a way to provide extra information
+and/or customize behaviour. See :ref:`sec-doc-metadata` for the syntax
+and what metadata you can set.
+
+.. _Markdown: http://daringfireball.net/projects/markdown/syntax
+.. _Markdown Extra: https://pythonhosted.org/Markdown/extensions/extra.html
+.. _CodeHilite: https://pythonhosted.org/Markdown/extensions/code_hilite.html
+.. _Meta-Data: https://pythonhosted.org/Markdown/extensions/meta_data.html
 
 LaTeX Support
 -------------

--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -74,7 +74,7 @@ in the opinion of this author, especially with regards to the list of
 arguments. Since version 1.0.0 it is now possible to place
 documentation before the code which it is documenting. To do so, use
 the ``predocmark``, which is set to ``>`` by default (it may be
-changed in the specify in the meta-data of your `project file
+changed in the specify in the metadata of your `project file
 <sec-project-options>`).  In the first line of your preceding
 documentation, use ``!>`` rather than the usual ``!!``. This can be
 used on all lines of the preceding documentation if desired, but this
@@ -87,7 +87,7 @@ documentation comment. Any immediately following lines containing only a
 comment will then be included in the block of documentation, without
 needing the “docmark”. The same effect can be achieved for preceding
 documentation by using the ``predocmark_alt``, set to ``|`` by default.
-Both of these may be changed in the project file meta-data.
+Both of these may be changed in the project file metadata.
 
 Legacy fixed-form FORTRAN code is now supported, using the `fixed2free
 <https://github.com/ylikx/fortran-legacy-tools/tree/master/fixed2free>`__


### PR DESCRIPTION
- Clarify that metadata in docstrings is always parsed, even if we don't use that key
- Fix some typos, links, and formatting

Fixes #530