### PR TITLE
Include type-bound procedures in call graphs if binding not visible 

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -259,7 +259,7 @@ def get_call_nodes(calls, visited=None, result=None):
     be nodes in the graph
 
     not all calls are a node, some are not visible, and some are simple
-    procedure bindings (bindings that bind one procedure to one label)
+    procedure bindings (bindings that bind one visible procedure to one label)
 
     these should be skipped, and show a call to their descendant instead
     """
@@ -280,6 +280,7 @@ def get_call_nodes(calls, visited=None, result=None):
             isinstance(call, FortranBoundProcedure)
             and len(call.bindings) == 1
             and not isinstance(call.bindings[0], FortranBoundProcedure)
+            and call.bindings[0].visible
         )
 
         if getattr(call, "visible", True) and not is_simple_binding:

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -255,7 +255,11 @@ class GraphData:
         return cast(TypeNode, self.get_node(type_, hist))
 
 
-def get_call_nodes(calls, visited=None, result=None):
+def get_call_nodes(
+    calls: List[Union[str, FortranEntity]],
+    visited: Optional[Set[Union[str, FortranEntity]]] = None,
+    result: Optional[Set[Union[str, FortranEntity]]] = None,
+) -> Set[Union[str, FortranEntity]]:
     """
     takes a list of calls, and returns a set of all the calls that should
     be nodes in the graph

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -41,6 +41,7 @@ from tqdm.contrib.concurrent import process_map
 import ford.utils
 
 from ford.sourceform import (
+    ExternalBoundProcedure,
     ExternalFunction,
     ExternalInterface,
     ExternalModule,
@@ -322,6 +323,7 @@ class BaseNode:
                 ExternalModule,
                 ExternalSubmodule,
                 ExternalType,
+                ExternalBoundProcedure,
                 ExternalSubroutine,
                 ExternalFunction,
                 ExternalInterface,
@@ -634,6 +636,7 @@ if graphviz_installed:
     _subroutine = gd.get_node(ExternalSubroutine("Subroutine"))
     _function = gd.get_node(ExternalFunction("Function"))
     _interface = gd.get_node(ExternalInterface("Interface"))
+    _boundproc = gd.get_node(ExternalBoundProcedure("Type Bound Procedure"))
     _unknown_proc = ExternalSubroutine("Unknown Procedure Type")
     _unknown_proc.proctype = "Unknown"
     _unknown = gd.get_node(_unknown_proc)
@@ -663,7 +666,9 @@ if graphviz_installed:
 
     mod_svg = _make_legend([_module, _submodule, _subroutine, _function, _program])
     type_svg = _make_legend([_type])
-    call_svg = _make_legend([_subroutine, _function, _interface, _unknown, _program])
+    call_svg = _make_legend(
+        [_subroutine, _function, _interface, _boundproc, _unknown, _program]
+    )
     file_svg = _make_legend([_sourcefile])
 else:
     mod_svg = ""

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -282,7 +282,7 @@ def get_call_nodes(calls, visited=None, result=None):
             isinstance(call, FortranBoundProcedure)
             and len(call.bindings) == 1
             and not isinstance(call.bindings[0], FortranBoundProcedure)
-            and call.bindings[0].visible
+            and (call.deferred or getattr(call.bindings[0], "visible", False))
         )
 
         if getattr(call, "visible", True) and not is_simple_binding:

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -121,7 +121,8 @@ def is_blockdata(obj):
     return isinstance(obj, FortranBlockData)
 
 
-NodeCollection = Dict[FortranContainer, "BaseNode"]
+FortranEntity = Union[FortranContainer, FortranBoundProcedure]
+NodeCollection = Dict[FortranEntity, "BaseNode"]
 
 
 class GraphData:
@@ -153,7 +154,7 @@ class GraphData:
         self.show_proc_parent = show_proc_parent
 
     def _get_collection_and_node_type(
-        self, obj: FortranContainer
+        self, obj: FortranEntity
     ) -> Tuple[NodeCollection, Type["BaseNode"]]:
         """Helper function for `register` and `get_node`: get the
         appropriate container for ``obj``, and the corresponding node
@@ -181,7 +182,7 @@ class GraphData:
         )
 
     def register(
-        self, obj: FortranContainer, hist: Optional[NodeCollection] = None
+        self, obj: FortranEntity, hist: Optional[NodeCollection] = None
     ) -> None:
         """Create and store the graph node for ``obj``, if it hasn't
         already been registered
@@ -201,7 +202,7 @@ class GraphData:
             collection[obj] = NodeType(obj, self, hist)
 
     def get_node(
-        self, obj: FortranContainer, hist: Optional[NodeCollection] = None
+        self, obj: FortranEntity, hist: Optional[NodeCollection] = None
     ) -> BaseNode:
         """Returns the node corresponding to ``obj``. If does not
         already exist then it will create it.
@@ -312,7 +313,7 @@ class BaseNode:
 
     def __init__(
         self,
-        obj: Union[FortranContainer, str],
+        obj: Union[FortranEntity, str],
         graph_data: GraphData,
         hist: Optional[NodeCollection] = None,
     ):

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -909,9 +909,11 @@ class FortranGraph:
                   );
                 </script>"""
 
+        graph_help_name = f"{self.__class__.__name__}-help-text"
+
         legend_graph = f"""\
-        <div><a type="button" class="graph-help" data-toggle="modal" href="#graph-help-text">Help</a></div>
-          <div class="modal fade" id="graph-help-text" tabindex="-1" role="dialog">
+        <div><a type="button" class="graph-help" data-toggle="modal" href="#{graph_help_name}">Help</a></div>
+          <div class="modal fade" id="{graph_help_name}" tabindex="-1" role="dialog">
             <div class="modal-dialog modal-lg" role="document">
               <div class="modal-content">
                 <div class="modal-header">

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -351,7 +351,7 @@ class BaseNode:
             self.ident = f"{d}~{obj.ident}"
             self.name = obj.name
             if m := EM_RE.search(self.name):
-                self.name = "<<i>" + m.group(1).strip() + "</i>>"
+                self.name = f"<<i>{m.group(1).strip()}</i>>"
             self.url = obj.get_url()
 
         self.attribs["label"] = self.name

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1937,7 +1937,9 @@ class FortranType(FortranContainer):
         # Match up generic type-bound procedures to their particular bindings
         for proc in self.boundprocs:
             for bp in inherited_generic:
-                if bp.name.lower() == proc.name.lower() and hasattr(bp, "bindings"):
+                if bp.name.lower() == proc.name.lower() and isinstance(
+                    bp, FortranBoundProcedure
+                ):
                     proc.bindings = bp.bindings + proc.bindings
                     break
             if proc.generic:
@@ -2299,7 +2301,7 @@ class FortranBoundProcedure(FortranBase):
         self.proto = line["prototype"]
         if self.proto:
             self.proto = self.proto[1:-1].strip()
-        self.bindings = []
+        self.bindings: List[Union[str, FortranProcedure, FortranBoundProcedure]] = []
         if len(split) > 1:
             binds = self.SPLIT_RE.split(split[1])
             for bind in binds:
@@ -3043,6 +3045,7 @@ class ExternalBoundProcedure(FortranBoundProcedure):
         self.external_url = url
         self.parent = parent
         self.obj = "proc"
+        self.bindings = []
 
 
 class ExternalType(FortranType):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -69,7 +69,7 @@ COMMA_RE = re.compile(r",(?!\s)")
 NBSP_RE = re.compile(r" (?= )|(?<= ) ")
 DIM_RE = re.compile(r"^\w+\s*(\(.*\))\s*$")
 PROTO_RE = re.compile(r"(\*|\w+)\s*(?:\((.*)\))?")
-
+CALL_AND_WHITESPACE_RE = re.compile(r"\(\)|\s")
 
 base_url = ""
 
@@ -1058,7 +1058,7 @@ class FortranContainer(FortranBase):
 
         # Add call chains to self.calls
         for chain_str in call_chains:
-            call_chain = re.sub("\(\)|\s", "", chain_str).lower().split("%")
+            call_chain = CALL_AND_WHITESPACE_RE.sub("", chain_str).lower().split("%")
 
             if call_chain[0] in associations:
                 call_chain[0:1] = associations[call_chain[0]]

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -66,8 +66,11 @@ def make_project_graphs(tmp_path_factory, request):
         procedure :: six
         procedure :: ei => eight
         procedure :: ni => nine
+        procedure :: ten
         generic :: eight_nine => ei, ni
       end type alpha
+
+      private :: ten
 
       interface
         subroutine defined_elsewhere
@@ -108,6 +111,9 @@ def make_project_graphs(tmp_path_factory, request):
         class(alpha) :: this
         integer :: x
       end subroutine nine
+      subroutine ten(this)
+        class(alpha) :: this
+      end subroutine then
     end module c
 
     submodule (c) c_submod
@@ -129,6 +135,7 @@ def make_project_graphs(tmp_path_factory, request):
       x = y%six()
       call y%ei(1.0)
       call y%eight_nine(1.0)
+      call y%ten()
     contains
       subroutine three
         use external_mod
@@ -257,6 +264,7 @@ TYPE_GRAPH_KEY = ["Type"]
                 "c::alpha%eight",
                 "c::alpha%nine",
                 "c::alpha%eight_nine",
+                "c::alpha%ten",
             ],
             [
                 "proc~three->proc~one",
@@ -273,6 +281,7 @@ TYPE_GRAPH_KEY = ["Type"]
                 "none~eight_nine->proc~eight",
                 "none~eight_nine->proc~nine",
                 "interface~submod_proc->proc~submod_proc",
+                "program~foo->none~ten",
             ],
             PROC_GRAPH_KEY,
         ),
@@ -297,6 +306,7 @@ TYPE_GRAPH_KEY = ["Type"]
                 "c::alpha%eight",
                 "c::alpha%nine",
                 "c::alpha%eight_nine",
+                "c::alpha%ten",
             ],
             [
                 "proc~three->proc~one",
@@ -316,6 +326,7 @@ TYPE_GRAPH_KEY = ["Type"]
                 "none~eight_nine->proc~eight",
                 "none~eight_nine->proc~nine",
                 "interface~submod_proc->proc~submod_proc",
+                "program~foo->none~ten",
             ],
             PROC_GRAPH_KEY,
         ),

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -203,6 +203,7 @@ PROC_GRAPH_KEY = [
     "Subroutine",
     "Function",
     "Interface",
+    "Type Bound Procedure",
     "Unknown Procedure Type",
     "Program",
 ]


### PR DESCRIPTION
Fixes #538

Plus some other minor tidy-ups:

- fix "help" legend when pages have multiple graphs
- add type-bound procedures to graph legends

@JosephWood2001 I've changed the behaviour for type-bound procedures in call graphs slightly: they now count as "simple bindings" only if the single binding is visible. I wonder if this needs to be further refined. Maybe we should always add bound procedures anyway, even if they add a bit of clutter for simple bindings?