### PR TITLE
Delay applying markdown conversion till after correlate step

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -43,7 +43,7 @@ from ford._typing import PathLike
 from ford.pagetree import get_page_tree
 from ford._markdown import MetaMarkdown
 from ford.version import __version__
-from ford.settings import Settings, load_markdown_settings, load_toml_settings
+from ford.settings import ProjectSettings, load_markdown_settings, load_toml_settings
 
 
 __appname__ = "FORD"
@@ -273,7 +273,7 @@ def get_command_line_arguments() -> argparse.Namespace:
 
 def load_settings(
     proj_docs: str, directory: PathLike = pathlib.Path(".")
-) -> Tuple[str, Settings, MetaMarkdown]:
+) -> Tuple[str, ProjectSettings, MetaMarkdown]:
     """Load Ford settings from ``fpm.toml`` if present, or from
     metadata in supplied project file1
 
@@ -314,7 +314,7 @@ def load_settings(
 def parse_arguments(
     command_line_args: dict,
     proj_docs: str,
-    proj_data: Settings,
+    proj_data: ProjectSettings,
     directory: PathLike = pathlib.Path("."),
 ):
     """Consolidates arguments from the command line and from the project
@@ -399,7 +399,7 @@ def parse_arguments(
     return proj_data, proj_docs
 
 
-def main(proj_data: Settings, proj_docs: str, md: MetaMarkdown):
+def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
     """
     Main driver of FORD.
     """

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -425,8 +425,8 @@ def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
     # Convert the documentation from Markdown to HTML. Make sure to properly
     # handle LateX and metadata.
     base_url = ".." if proj_data.relative else proj_data.project_url
-    project.markdown(md, base_url)
     project.correlate()
+    project.markdown(md, base_url)
     project.make_links(base_url)
 
     # Convert summaries and descriptions to HTML

--- a/ford/_markdown.py
+++ b/ford/_markdown.py
@@ -11,7 +11,7 @@ class MetaMarkdown(Markdown):
 
     def __init__(
         self,
-        md_base: PathLike,
+        md_base: PathLike = ".",
         extensions: Optional[List[Union[str, Extension]]] = None,
         extension_configs: Optional[Dict[str, Dict]] = None,
     ):

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -47,7 +47,7 @@ from ford.sourceform import (
     ExternalVariable,
     FortranProcedure,
 )
-from ford.settings import Settings
+from ford.settings import ProjectSettings
 
 
 INTRINSIC_MODS = {
@@ -69,7 +69,7 @@ class Project:
     project which is to be documented.
     """
 
-    def __init__(self, settings: Settings):
+    def __init__(self, settings: ProjectSettings):
         self.settings = settings
         self.name = settings.project
         self.external = settings.external

--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -793,8 +793,8 @@ class FortranGraph:
 
         for r in root:
             self.root.append(self.data.get_node(r))
-            self.max_nesting = max(self.max_nesting, int(r.meta["graph_maxdepth"]))
-            self.max_nodes = max(self.max_nodes, int(r.meta["graph_maxnodes"]))
+            self.max_nesting = max(self.max_nesting, int(r.meta.graph_maxdepth))
+            self.max_nodes = max(self.max_nodes, int(r.meta.graph_maxnodes))
             self.warn = self.warn or (r.settings.warn)
 
         ident = ident or f"{root[0].get_dir()}~~{root[0].ident}"
@@ -1363,7 +1363,7 @@ class GraphManager:
 
     def register(self, obj: FortranContainer):
         """Register ``obj`` as a node to be used in graphs"""
-        if obj.meta["graph"]:
+        if obj.meta.graph:
             self.data.register(obj)
             self.graph_objs.append(obj)
 

--- a/ford/output.py
+++ b/ford/output.py
@@ -39,7 +39,7 @@ import ford.sourceform
 import ford.tipue_search
 import ford.utils
 from ford.graphs import graphviz_installed, GraphManager
-from ford.settings import Settings
+from ford.settings import ProjectSettings
 
 loc = pathlib.Path(__file__).parent
 env = jinja2.Environment(
@@ -83,7 +83,7 @@ class Documentation:
     a project.
     """
 
-    def __init__(self, settings: Settings, proj_docs: str, project, pagetree):
+    def __init__(self, settings: ProjectSettings, proj_docs: str, project, pagetree):
         # This lets us use meta data anywhere within the template.
         # Also, in future for other template, we may not need to
         # pass the data obj.

--- a/ford/output.py
+++ b/ford/output.py
@@ -39,7 +39,7 @@ import ford.sourceform
 import ford.tipue_search
 import ford.utils
 from ford.graphs import graphviz_installed, GraphManager
-from ford.settings import ProjectSettings
+from ford.settings import ProjectSettings, EntitySettings
 
 loc = pathlib.Path(__file__).parent
 env = jinja2.Environment(
@@ -68,7 +68,7 @@ def meta(entity, item):
             "please check that this file compiles with a Fortran compiler"
         )
 
-    return entity.meta.get(item, None)
+    return getattr(entity.meta, item, None)
 
 
 env.tests["more_than_one"] = is_more_than_one
@@ -202,7 +202,9 @@ class Documentation:
             self.tipue = ford.tipue_search.Tipue_Search_JSON_Generator(
                 settings.output_dir, url
             )
-            self.tipue.create_node(self.index.html, "index.html", {"category": "home"})
+            self.tipue.create_node(
+                self.index.html, "index.html", EntitySettings(category="home")
+            )
             jobs = len(self.docs) + len(self.pagetree)
             for p in tqdm(
                 chain(self.docs, self.pagetree),
@@ -299,7 +301,7 @@ class BasePage:
         self.data = data
         self.proj = proj
         self.obj = obj
-        self.meta = getattr(obj, "meta", {})
+        self.meta = getattr(obj, "meta", EntitySettings())
         self.out_dir = self.data["output_dir"]
         self.page_dir = self.out_dir / "page"
 

--- a/ford/pagetree.py
+++ b/ford/pagetree.py
@@ -70,7 +70,7 @@ class PageNode:
         #   project settings
         self.copy_subdir = self.meta.copy_subdir or proj_copy_subdir
         self.parent = parent
-        self.contents = md.reset().convert(text)
+        self.contents = md.reset().convert("\n".join(text))
         self.subpages: List[PageNode] = []
         self.files: List[os.PathLike] = []
         self.filename = Path(path.stem)

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -73,7 +73,7 @@ def convert_to_bool(name: str, option: List[str]) -> bool:
 
 
 @dataclass
-class Settings:
+class ProjectSettings:
     alias: List[str] = field(default_factory=list)
     author: Optional[str] = None
     author_description: Optional[str] = None
@@ -215,7 +215,7 @@ class Settings:
             self.md_base_dir = directory
 
 
-def load_toml_settings(directory: PathLike) -> Optional[Settings]:
+def load_toml_settings(directory: PathLike) -> Optional[ProjectSettings]:
     """Load Ford settings from ``fpm.toml`` file in ``directory``
 
     Settings should be in ``[extra.ford]`` table
@@ -235,14 +235,14 @@ def load_toml_settings(directory: PathLike) -> Optional[Settings]:
     if "ford" not in settings["extra"]:
         return None
 
-    return Settings(**settings["extra"]["ford"])
+    return ProjectSettings(**settings["extra"]["ford"])
 
 
 def load_markdown_settings(
     directory: PathLike, project_file: str
-) -> Tuple[Settings, str]:
+) -> Tuple[ProjectSettings, str]:
     settings, project_file = meta_preprocessor(project_file)
-    field_types = get_type_hints(Settings)
+    field_types = get_type_hints(ProjectSettings)
 
     keys_to_drop = []
 
@@ -284,4 +284,4 @@ def load_markdown_settings(
     for key in keys_to_drop:
         settings.pop(key)
 
-    return Settings(**settings), project_file
+    return ProjectSettings(**settings), project_file

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -290,7 +290,7 @@ def load_markdown_settings(
     for key in keys_to_drop:
         settings.pop(key)
 
-    return ProjectSettings.from_markdown_metadata(settings), project_file
+    return ProjectSettings.from_markdown_metadata(settings), "\n".join(project_file)
 
 
 def convert_types_from_metapreprocessor(cls: Type, settings: Dict[str, Any]):

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -247,7 +247,7 @@ def load_toml_settings(directory: PathLike) -> Optional[ProjectSettings]:
 def load_markdown_settings(
     directory: PathLike, project_file: str
 ) -> Tuple[ProjectSettings, str]:
-    settings, project_file = meta_preprocessor(project_file)
+    settings, project_lines = meta_preprocessor(project_file)
     field_types = get_type_hints(ProjectSettings)
 
     keys_to_drop = []
@@ -290,7 +290,7 @@ def load_markdown_settings(
     for key in keys_to_drop:
         settings.pop(key)
 
-    return ProjectSettings.from_markdown_metadata(settings), "\n".join(project_file)
+    return ProjectSettings.from_markdown_metadata(settings), "\n".join(project_lines)
 
 
 def convert_types_from_metapreprocessor(cls: Type, settings: Dict[str, Any]):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -45,7 +45,7 @@ from ford.reader import FortranReader
 import ford.utils
 from ford.intrinsics import INTRINSICS
 from ford._markdown import MetaMarkdown
-from ford.settings import Settings
+from ford.settings import ProjectSettings
 
 if TYPE_CHECKING:
     from ford.fortran_project import Project
@@ -182,11 +182,11 @@ class FortranBase:
         if self.parent:
             self.parobj: Optional[str] = self.parent.obj
             self.display: List[str] = self.parent.display
-            self.settings: Settings = self.parent.settings
+            self.settings: ProjectSettings = self.parent.settings
         else:
             self.parobj = None
             self.display = []
-            self.settings = Settings()
+            self.settings = ProjectSettings()
 
         self._initialize(first_line)
         del self.strings
@@ -1478,7 +1478,7 @@ class FortranSourceFile(FortranContainer):
     def __init__(
         self,
         filepath: str,
-        settings: Settings,
+        settings: ProjectSettings,
         preprocessor=None,
         fixed: bool = False,
         **kwargs,
@@ -2602,7 +2602,7 @@ class GenericSource(FortranBase):
     not be analyzed, but documentation can be extracted.
     """
 
-    def __init__(self, filename, settings: Settings):
+    def __init__(self, filename, settings: ProjectSettings):
         self.obj = "sourcefile"
         self.parobj = None
         self.parent = None

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -192,8 +192,8 @@ class FortranBase:
         del self.strings
 
         self.doc_list = read_docstring(source, self.settings.docmark)
-        self.read_metadata()
         self.hierarchy = self._make_hierarchy()
+        self.read_metadata()
 
         # Some entities are reachable from more than one parent (for example,
         # public procedures that are also part of a generic interface), so we
@@ -2137,7 +2137,6 @@ class FortranModuleProcedureInterface(FortranInterface):
         self.visible = parent.visible
         self.num_lines = parent.num_lines
         self.doc_list = doc_list
-        self.read_metadata()
         self.variables = copy.copy(parent.variables)
 
         self.procedure = procedure
@@ -2146,6 +2145,7 @@ class FortranModuleProcedureInterface(FortranInterface):
         self.procedure.parent = self
 
         self.hierarchy = self._make_hierarchy()
+        self.read_metadata()
         self._done_markdown = False
 
 
@@ -2164,8 +2164,8 @@ class FortranFinalProc(FortranBase):
         self.display = self.parent.display
         self.settings = self.parent.settings
         self.doc_list = read_docstring(source, self.settings.docmark) if source else []
-        self.read_metadata()
         self.hierarchy = self._make_hierarchy()
+        self.read_metadata()
         self._done_markdown = False
 
     def correlate(self, project):
@@ -2213,7 +2213,6 @@ class FortranVariable(FortranBase):
         self.strlen = strlen
         self.proto = copy.copy(proto)
         self.doc_list = copy.copy(doc) if doc is not None else []
-        self.read_metadata()
         self.permission = permission
         self.points = points
         self.parameter = parameter
@@ -2238,6 +2237,7 @@ class FortranVariable(FortranBase):
             self.name = self.name[0 : min(indexlist)]
 
         self.hierarchy = self._make_hierarchy()
+        self.read_metadata()
 
     def correlate(self, project):
         if not self.proto:
@@ -2401,8 +2401,8 @@ class FortranModuleProcedureReference(FortranBase):
         self.name = name
         self.procedure = None
         self.doc_list = []
-        self.read_metadata()
         self.hierarchy = self._make_hierarchy()
+        self.read_metadata()
         self._done_markdown = False
 
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2591,6 +2591,7 @@ class GenericSource(FortranBase):
         self.hierarchy = []
         self.settings = settings
         self.num_lines = 0
+        self._done_markdown = False
         extra_filetypes = settings.extra_filetypes[filename.split(".")[-1]]
         comchar = extra_filetypes[0]
         if len(extra_filetypes) > 1:
@@ -2710,6 +2711,8 @@ class GenericSource(FortranBase):
                 self.doc_list.append("")
                 prevdoc = False
             docalt = False
+
+        self.read_metadata()
 
     def lines_description(self, total, total_all=0):
         return ""

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -3075,6 +3075,9 @@ class ExternalVariable(FortranVariable):
         self.external_url = url
         self.parent = parent
         self.obj = "variable"
+        self.kind = None
+        self.strlen = None
+        self.proto = None
 
 
 class ExternalSubmodule(FortranSubmodule):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -188,9 +188,6 @@ class FortranBase:
             self.display = []
             self.settings = ProjectSettings()
 
-        self._initialize(first_line)
-        del self.strings
-
         self.doc_list = read_docstring(source, self.settings.docmark)
         self.hierarchy = self._make_hierarchy()
         self.read_metadata()
@@ -199,6 +196,9 @@ class FortranBase:
         # public procedures that are also part of a generic interface), so we
         # need to make sure we don't convert the docstrings twice
         self.source_file._to_be_markdowned.append(self)
+
+        self._initialize(first_line)
+        del self.strings
 
     def _make_hierarchy(self) -> List[FortranContainer]:
         """Create list of ancestor entities"""
@@ -2068,6 +2068,9 @@ class FortranInterface(FortranContainer):
         self.abstract = bool(line.group(1))
         if self.generic and self.abstract:
             raise Exception(f"Generic interface '{self.name}' can not be abstract")
+
+        if self.abstract:
+            self.source_file._to_be_markdowned.remove(self)
 
     def correlate(self, project):
         self.all_absinterfaces = self.parent.all_absinterfaces

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -395,7 +395,7 @@ class FortranBase:
 
         # Create Markdown
         for item in self.children:
-            if isinstance(item, FortranBase):
+            if isinstance(item, FortranBase) and not hasattr(item, "external_url"):
                 item.markdown(md, project)
 
     def sort_components(self) -> None:

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -771,27 +771,27 @@
 
 
 {% macro meta_list(meta) %}
-  {% if meta['author'] or meta['date'] or meta['license'] or meta['version'] or meta['category'] %}
+  {% if meta.author or meta.date or meta.license or meta.version or meta.category %}
     <dl class="dl-horizontal">
-      {% if meta['author'] %}
-        <dt>Author</dt><dd>{{ meta['author'] }}</dd>
+      {% if meta.author %}
+        <dt>Author</dt><dd>{{ meta.author }}</dd>
       {% endif %}
-      {% if meta['date'] %}
-        <dt>Date</dt><dd>{{ meta['date'] }}</dd>
+      {% if meta.date %}
+        <dt>Date</dt><dd>{{ meta.date }}</dd>
       {% endif %}
-      {% if meta['license'] %}
-        <dt>License</dt><dd>{{ meta['license'] }}</dd>
+      {% if meta.license %}
+        <dt>License</dt><dd>{{ meta.license }}</dd>
       {% elif projectData['license'] %}
         <dt>License</dt><dd>{{ projectData['license'] }}</dd>
       {% endif %}
-      {% if meta['since'] %}
-        <dt>Since</dt><dd>{{ meta['since'] }}</dd>
+      {% if meta.since %}
+        <dt>Since</dt><dd>{{ meta.since }}</dd>
       {% endif %}
-      {% if meta['version'] %}
-        <dt>Version</dt><dd>{{ meta['version'] }}</dd>
+      {% if meta.version %}
+        <dt>Version</dt><dd>{{ meta.version }}</dd>
       {% endif %}
-      {% if meta['category'] %}
-        <dt>Category</dt><dd>{{ meta['category'] }}</dd>
+      {% if meta.category %}
+        <dt>Category</dt><dd>{{ meta.category }}</dd>
       {% endif %}
     </dl>
   {% endif %}

--- a/ford/templates/mod_list.html
+++ b/ford/templates/mod_list.html
@@ -4,7 +4,7 @@ All Modules &ndash; {{ project }}
 {% endblock %}
 {% block body %}
 {% macro mod_entry(mod,level) %}
-    <tr><td>{{ mod }}</td><td>{{ mod.parent }}</td><td>{{ mod.meta['summary'] }}</td></tr>
+    <tr><td>{{ mod }}</td><td>{{ mod.parent }}</td><td>{{ mod.meta.summary }}</td></tr>
     {% for m in mod.descendants %}
         
     {% endfor %}
@@ -17,7 +17,7 @@ All Modules &ndash; {{ project }}
 			 <tbody>
              {% set row_class = cycler('active', '') %}
 			 {% for mod in project.modules|sort(attribute='name') recursive %}
-			   <tr class="{% if loop.depth == 1 %}{{ row_class.current }}{% else %}{{ row_class.current }} submod{% endif %}"><td>{% for i in range(loop.depth0) -%}&nbsp;&nbsp;&nbsp;{%- endfor %}{{ mod }}</td><td>{{ mod.parent }}</td><td>{{ mod.meta['summary'] }}</td></tr>
+			   <tr class="{% if loop.depth == 1 %}{{ row_class.current }}{% else %}{{ row_class.current }} submod{% endif %}"><td>{% for i in range(loop.depth0) -%}&nbsp;&nbsp;&nbsp;{%- endfor %}{{ mod }}</td><td>{{ mod.parent }}</td><td>{{ mod.meta.summary }}</td></tr>
                {% if mod.descendants %}
                   {{ loop(mod.descendants) }}
                {% endif %}

--- a/ford/templates/types_list.html
+++ b/ford/templates/types_list.html
@@ -11,7 +11,7 @@ All Types &ndash; {{ project }}
 			 <tr><th>Type</th><th>Location</th><th>Extends</th><th>Description</th></tr>
 			 </thead><tbody>
 			 {% for dtype in project.types|sort(attribute='name') %}
-			   <tr><td>{{ dtype }}</td><td>{{ dtype.parent }}</td><td>{{ dtype.extends }}</td><td>{{ dtype.meta['summary'] }}</td></tr>
+			   <tr><td>{{ dtype }}</td><td>{{ dtype.parent }}</td><td>{{ dtype.extends }}</td><td>{{ dtype.meta.summary }}</td></tr>
 			 {% endfor %}
 			 </tbody></table>
              {{ project.typegraph }}

--- a/ford/tipue_search.py
+++ b/ford/tipue_search.py
@@ -41,6 +41,8 @@ from codecs import open
 from typing import Dict, List
 from urllib.parse import urljoin
 
+from ford.settings import EntitySettings
+
 
 class Tipue_Search_JSON_Generator:
     def __init__(self, output_path: os.PathLike, project_url: str):
@@ -50,7 +52,7 @@ class Tipue_Search_JSON_Generator:
         self.only_text = SoupStrainer("div", id="text")
         self.only_title = SoupStrainer("title")
 
-    def create_node(self, html, loc, meta={}):
+    def create_node(self, html, loc, meta: EntitySettings):
         try:
             soup = BeautifulSoup(html, "lxml", parse_only=self.only_text)
             soup_title = BeautifulSoup(html, "lxml", parse_only=self.only_title)
@@ -76,10 +78,7 @@ class Tipue_Search_JSON_Generator:
             page_title = ""
 
         # Should set default category?
-        if "category" in meta:
-            page_category = meta["category"]
-        else:
-            page_category = ""
+        page_category = meta.category or ""
 
         if self.siteurl != "":
             page_url = urljoin(self.siteurl, loc)

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -389,7 +389,7 @@ BEGIN_RE = re.compile(r"^-{3}(\s.*)?")
 END_RE = re.compile(r"^(-{3}|\.{3})(\s.*)?")
 
 
-def meta_preprocessor(lines: Union[str, List[str]]) -> Tuple[Dict[str, Any], str]:
+def meta_preprocessor(lines: Union[str, List[str]]) -> Tuple[Dict[str, Any], List[str]]:
     """Extract metadata from start of ``lines``
 
     This is modified from the `Meta-Data Python Markdown extension`_
@@ -405,7 +405,7 @@ def meta_preprocessor(lines: Union[str, List[str]]) -> Tuple[Dict[str, Any], str
     meta:
         Dictionary of metadata, with lowercase keys
     lines:
-        Original text with metadata lines removed
+        Original text with metadata lines removed as list
 
     Notes
     -----
@@ -447,4 +447,4 @@ def meta_preprocessor(lines: Union[str, List[str]]) -> Tuple[Dict[str, Any], str
             else:
                 lines.insert(0, line)
                 break  # no meta data - done
-    return meta, "\n".join(lines)
+    return meta, lines

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -1,5 +1,5 @@
 from ford.fortran_project import Project
-from ford import Settings
+from ford import ProjectSettings
 from ford.graphs import graphviz_installed, GraphManager
 import ford.sourceform
 
@@ -162,7 +162,9 @@ def make_project_graphs(tmp_path_factory, request):
     with open(full_filename, "w") as f:
         f.write(dedent(data))
 
-    settings = Settings(src_dir=src_dir, graph=True, proc_internals=proc_internals)
+    settings = ProjectSettings(
+        src_dir=src_dir, graph=True, proc_internals=proc_internals
+    )
     project = create_project((settings))
 
     graphs = GraphManager(
@@ -512,7 +514,7 @@ def test_graphs_as_table(tmp_path):
     with open(full_filename, "w") as f:
         f.write(dedent(data))
 
-    settings = Settings(src_dir=src_dir, graph=True, graph_maxnodes=4)
+    settings = ProjectSettings(src_dir=src_dir, graph=True, graph_maxnodes=4)
     project = create_project((settings))
 
     graphs = GraphManager(

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -165,7 +165,7 @@ def make_project_graphs(tmp_path_factory, request):
     settings = ProjectSettings(
         src_dir=src_dir, graph=True, proc_internals=proc_internals
     )
-    project = create_project((settings))
+    project = create_project(settings)
 
     graphs = GraphManager(
         graphdir="", parentdir="..", coloured_edges=True, show_proc_parent=True

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -45,11 +45,11 @@ def test_quiet_command_line():
     """Check that setting --quiet on the command line overrides project file"""
 
     data, _ = ford.parse_arguments(
-        {"quiet": True, "preprocess": False}, "", ford.Settings(quiet=False)
+        {"quiet": True, "preprocess": False}, "", ford.ProjectSettings(quiet=False)
     )
     assert data.quiet is True
     data, _ = ford.parse_arguments(
-        {"quiet": False, "preprocess": False}, "", (ford.Settings(quiet=True))
+        {"quiet": False, "preprocess": False}, "", (ford.ProjectSettings(quiet=True))
     )
     assert data.quiet is False
 
@@ -77,7 +77,7 @@ def test_path_normalisation():
     data, _ = ford.parse_arguments(
         {"preprocess": False},
         "",
-        ford.Settings(page_dir="my_pages", src_dir=["src1", "src2"]),
+        ford.ProjectSettings(page_dir="my_pages", src_dir=["src1", "src2"]),
         directory="/prefix/path",
     )
     assert data.page_dir == Path("/prefix/path/my_pages").absolute()
@@ -94,7 +94,7 @@ def test_source_not_subdir_output():
     data, _ = ford.parse_arguments(
         {"src_dir": ["/1/2/3", "4/5"], "output_dir": "/3/4", "preprocess": False},
         "",
-        ford.Settings(),
+        ford.ProjectSettings(),
         directory="/prefix",
     )
 
@@ -103,7 +103,7 @@ def test_source_not_subdir_output():
         data, _ = ford.parse_arguments(
             {"src_dir": ["4/5", "/1/2/3"], "output_dir": "/1/2", "preprocess": False},
             "",
-            ford.Settings(),
+            ford.ProjectSettings(),
             directory="/prefix",
         )
     # src_dir == output_dir
@@ -111,7 +111,7 @@ def test_source_not_subdir_output():
         data, _ = ford.parse_arguments(
             {"src_dir": ["/1/2/"], "output_dir": "/1/2", "preprocess": False},
             "",
-            ford.Settings(),
+            ford.ProjectSettings(),
             directory="/prefix",
         )
 
@@ -123,26 +123,28 @@ def test_repeated_docmark():
         ford.parse_arguments(
             {"preprocess": False},
             "",
-            (ford.Settings(**{"docmark": "!", "predocmark": "!"})),
+            (ford.ProjectSettings(**{"docmark": "!", "predocmark": "!"})),
         )
 
     with pytest.raises(ValueError):
         ford.parse_arguments(
             {"preprocess": False},
             "",
-            (ford.Settings(**{"docmark": "!<", "predocmark_alt": "!<"})),
+            (ford.ProjectSettings(**{"docmark": "!<", "predocmark_alt": "!<"})),
         )
 
     with pytest.raises(ValueError):
         ford.parse_arguments(
             {"preprocess": False},
             "",
-            (ford.Settings(**{"docmark_alt": "!!", "predocmark_alt": "!!"})),
+            (ford.ProjectSettings(**{"docmark_alt": "!!", "predocmark_alt": "!!"})),
         )
 
 
 def test_no_preprocessor():
-    data, _ = ford.parse_arguments({}, "", (ford.Settings(**{"preprocess": False})))
+    data, _ = ford.parse_arguments(
+        {}, "", (ford.ProjectSettings(**{"preprocess": False}))
+    )
 
     assert data.fpp_extensions == []
 
@@ -152,7 +154,7 @@ def test_bad_preprocessor():
         ford.parse_arguments(
             {"project_file": FakeFile()},
             "",
-            (ford.Settings(**{"preprocessor": "false"})),
+            (ford.ProjectSettings(**{"preprocessor": "false"})),
         )
 
 
@@ -160,7 +162,9 @@ def test_bad_preprocessor():
     sys.platform.startswith("win"), reason="FIXME: Need portable do-nothing command"
 )
 def test_maybe_ok_preprocessor():
-    data, _ = ford.parse_arguments({}, "", (ford.Settings(**{"preprocessor": "true"})))
+    data, _ = ford.parse_arguments(
+        {}, "", (ford.ProjectSettings(**{"preprocessor": "true"}))
+    )
 
     if data.preprocess is True:
         assert data.preprocessor == "true"
@@ -171,7 +175,7 @@ def test_maybe_ok_preprocessor():
 )
 def test_gfortran_preprocessor():
     data, _ = ford.parse_arguments(
-        {}, "", (ford.Settings(**{"preprocessor": "gfortran -E"}))
+        {}, "", (ford.ProjectSettings(**{"preprocessor": "gfortran -E"}))
     )
 
     assert data.preprocess is True

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1,5 +1,5 @@
 from ford.fortran_project import Project
-from ford import Settings
+from ford import ProjectSettings
 from ford.utils import normalise_path
 from ford.sourceform import FortranVariable
 
@@ -19,7 +19,7 @@ def copy_fortran_file(tmp_path):
         filename = src_dir / "test.f90"
         with open(filename, "w") as f:
             f.write(data)
-        return Settings(src_dir=src_dir)
+        return ProjectSettings(src_dir=src_dir)
 
     return copy_file
 
@@ -746,7 +746,9 @@ def test_exclude_dir(tmp_path):
     with open(exclude_dir / "exclude.f90", "w") as f:
         f.write("program bar\nend program")
 
-    settings = Settings(src_dir=tmp_path, exclude_dir=normalise_path(tmp_path, "sub1"))
+    settings = ProjectSettings(
+        src_dir=tmp_path, exclude_dir=normalise_path(tmp_path, "sub1")
+    )
     project = Project((settings))
 
     program_names = {program.name for program in project.programs}
@@ -764,7 +766,7 @@ def test_exclude(tmp_path):
     with open(exclude_dir / "exclude.f90", "w") as f:
         f.write("program bar\nend program")
 
-    settings = Settings(src_dir=tmp_path, exclude="exclude.f90")
+    settings = ProjectSettings(src_dir=tmp_path, exclude="exclude.f90")
     project = Project((settings))
 
     program_names = {program.name for program in project.programs}

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,4 +1,4 @@
-from ford.settings import is_same_type, Settings, load_markdown_settings
+from ford.settings import is_same_type, ProjectSettings, load_markdown_settings
 
 from typing import List, Optional
 from textwrap import dedent
@@ -19,7 +19,7 @@ def test_is_same_type(type_in, tp, expected):
 
 
 def test_settings_type_conversion():
-    settings = Settings(src_dir="./src")
+    settings = ProjectSettings(src_dir="./src")
 
     assert settings.src_dir == ["./src"]
 

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,4 +1,9 @@
-from ford.settings import is_same_type, ProjectSettings, load_markdown_settings
+from ford.settings import (
+    is_same_type,
+    ProjectSettings,
+    load_markdown_settings,
+    EntitySettings,
+)
 
 from typing import List, Optional
 from textwrap import dedent
@@ -49,3 +54,18 @@ def test_settings_type_conversion_from_markdown():
     assert settings.summary == "first\nsecond"
     assert settings.preprocess is True
     assert settings.max_frontpage_items == 4
+
+
+def test_entity_settings_from_project():
+    project_settings = ProjectSettings(source=True)
+    entity_settings = EntitySettings.from_project_settings(project_settings)
+    assert entity_settings.source is True
+
+
+def test_update_entity_settings():
+    expected_version = "1.0.1"
+    settings = EntitySettings(source=True)
+    settings.update({"version": expected_version})
+
+    assert settings.source is True
+    assert settings.version == expected_version

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -8,12 +8,12 @@ from ford.sourceform import (
 )
 from ford.fortran_project import find_used_modules
 from ford import ProjectSettings
+from ford._markdown import MetaMarkdown
 
 from dataclasses import dataclass, field
 from typing import Union, List, Optional
 from itertools import chain
 
-import markdown
 import pytest
 
 
@@ -27,7 +27,7 @@ def parse_fortran_file(copy_fortran_file):
     def parse_file(data, **kwargs):
         filename = copy_fortran_file(data)
         settings = ProjectSettings(**kwargs)
-        return FortranSourceFile(str(filename), (settings))
+        return FortranSourceFile(str(filename), settings)
 
     return parse_file
 
@@ -1363,14 +1363,7 @@ def test_markdown_header_bug286(parse_fortran_file):
     """
 
     fortran_file = parse_fortran_file(data)
-    md_ext = [
-        "markdown.extensions.meta",
-        "markdown.extensions.codehilite",
-        "markdown.extensions.extra",
-    ]
-    md = markdown.Markdown(
-        extensions=md_ext, output_format="html5", extension_configs={}
-    )
+    md = MetaMarkdown()
 
     subroutine = fortran_file.modules[0].subroutines[0]
     subroutine.markdown(md, None)
@@ -1395,14 +1388,7 @@ def test_markdown_codeblocks_bug286(parse_fortran_file):
     """
 
     fortran_file = parse_fortran_file(data)
-    md_ext = [
-        "markdown.extensions.meta",
-        "markdown.extensions.codehilite",
-        "markdown.extensions.extra",
-    ]
-    md = markdown.Markdown(
-        extensions=md_ext, output_format="html5", extension_configs={}
-    )
+    md = MetaMarkdown()
 
     subroutine = fortran_file.modules[0].subroutines[0]
     subroutine.markdown(md, None)
@@ -1430,20 +1416,12 @@ def test_markdown_meta_reset(parse_fortran_file):
     """
 
     fortran_file = parse_fortran_file(data)
-    md_ext = [
-        "markdown.extensions.meta",
-        "markdown.extensions.codehilite",
-        "markdown.extensions.extra",
-    ]
-    md = markdown.Markdown(
-        extensions=md_ext, output_format="html5", extension_configs={}
-    )
-
+    md = MetaMarkdown()
     module = fortran_file.modules[0]
     module.markdown(md, None)
-    assert module.meta["version"] == "0.1.0"
-    assert module.subroutines[0].meta["author"] == "Test name"
-    assert "author" not in module.subroutines[1].meta
+    assert module.meta.version == "0.1.0"
+    assert module.subroutines[0].meta.author == "Test name"
+    assert module.subroutines[1].meta.author is None
 
 
 def test_multiline_attributes(parse_fortran_file):
@@ -1485,20 +1463,13 @@ def test_markdown_source_meta(parse_fortran_file):
     end subroutine with_source
     """
 
-    md_ext = [
-        "markdown.extensions.meta",
-        "markdown.extensions.codehilite",
-        "markdown.extensions.extra",
-    ]
-    md = markdown.Markdown(
-        extensions=md_ext, output_format="html5", extension_configs={}
-    )
+    md = MetaMarkdown()
 
     fortran_file = parse_fortran_file(data)
     subroutine = fortran_file.subroutines[0]
     subroutine.markdown(md, None)
 
-    assert subroutine.meta["source"]
+    assert subroutine.meta.source is True
     assert "with_source" in subroutine.src
 
 
@@ -1511,20 +1482,12 @@ def test_markdown_source_settings(parse_fortran_file):
     end subroutine with_source
     """
 
-    md_ext = [
-        "markdown.extensions.meta",
-        "markdown.extensions.codehilite",
-        "markdown.extensions.extra",
-    ]
-    md = markdown.Markdown(
-        extensions=md_ext, output_format="html5", extension_configs={}
-    )
-
+    md = MetaMarkdown()
     fortran_file = parse_fortran_file(data, source=True)
     subroutine = fortran_file.subroutines[0]
     subroutine.markdown(md, None)
 
-    assert subroutine.meta["source"]
+    assert subroutine.meta.source is True
     assert "with_source" in subroutine.src
 
 

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1238,6 +1238,7 @@ class FakeParent:
     obj: str = "module"
     parent = None
     display: List[str] = field(default_factory=list)
+    _to_be_markdowned: List[FortranBase] = field(default_factory=list)
 
 
 def _make_list_str() -> List[str]:
@@ -1332,6 +1333,7 @@ class FakeVariable:
 def test_line_to_variable(line, expected_variables):
     variables = line_to_variables(FakeSource(), line, "public", FakeParent())
     attributes = expected_variables[0].__dict__
+    attributes.pop("parent")
 
     for variable, expected in zip(variables, expected_variables):
         for attr in attributes:
@@ -1340,7 +1342,6 @@ def test_line_to_variable(line, expected_variables):
             assert variable_attr == expected_attr, attr
 
     if len(expected_variables) > 1:
-        attributes.pop("parent")
         for attr in attributes:
             attribute = getattr(variable, attr)
             if not isinstance(attribute, list):

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -7,7 +7,7 @@ from ford.sourceform import (
     line_to_variables,
 )
 from ford.fortran_project import find_used_modules
-from ford import Settings
+from ford import ProjectSettings
 
 from dataclasses import dataclass, field
 from typing import Union, List, Optional
@@ -26,7 +26,7 @@ class FakeProject:
 def parse_fortran_file(copy_fortran_file):
     def parse_file(data, **kwargs):
         filename = copy_fortran_file(data)
-        settings = Settings(**kwargs)
+        settings = ProjectSettings(**kwargs)
         return FortranSourceFile(str(filename), (settings))
 
     return parse_file
@@ -1234,7 +1234,7 @@ class FakeSource:
 @dataclass
 class FakeParent:
     strings: List[str] = field(default_factory=lambda: ['"Hello"', "'World'"])
-    settings: Settings = field(default_factory=Settings)
+    settings: ProjectSettings = field(default_factory=ProjectSettings)
     obj: str = "module"
     parent = None
 

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1237,6 +1237,7 @@ class FakeParent:
     settings: ProjectSettings = field(default_factory=ProjectSettings)
     obj: str = "module"
     parent = None
+    display: List[str] = field(default_factory=list)
 
 
 def _make_list_str() -> List[str]:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -70,7 +70,7 @@ def test_meta_preprocessor():
 
     meta, doc = meta_preprocessor(text)
 
-    assert doc == "no more metadata"
+    assert doc == ["no more metadata"]
     assert meta == {
         "key1": ["value1"],
         "key2": ["value2", "value2a"],


### PR DESCRIPTION
Metadata set in an entity's docstring is now read as soon as possible and separately to the markdown conversion. This allows us to wait till after the correlate step to do the markdown conversion, which will be important for replacing `sub_links` with a markdown extension.

This PR also converts the entity metadata to a dataclass, which gives us better type checking and auto-completion, etc, for the metadata.