### PR TITLE
Convert `sub_macros` to a markdown extension

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -24,6 +24,7 @@
 #
 
 from contextlib import contextmanager
+import copy
 from io import StringIO
 import sys
 import argparse
@@ -126,9 +127,9 @@ def initialize():
 
     proj_docs = args.project_file.read()
     directory = os.path.dirname(args.project_file.name)
-    proj_docs, proj_data, md = load_settings(proj_docs, directory)
+    proj_docs, proj_data = load_settings(proj_docs, directory)
 
-    return *parse_arguments(vars(args), proj_docs, proj_data, directory), md
+    return parse_arguments(vars(args), proj_docs, proj_data, directory)
 
 
 def get_command_line_arguments() -> argparse.Namespace:
@@ -273,7 +274,7 @@ def get_command_line_arguments() -> argparse.Namespace:
 
 def load_settings(
     proj_docs: str, directory: PathLike = pathlib.Path(".")
-) -> Tuple[str, ProjectSettings, MetaMarkdown]:
+) -> Tuple[str, ProjectSettings]:
     """Load Ford settings from ``fpm.toml`` if present, or from
     metadata in supplied project file1
 
@@ -290,8 +291,6 @@ def load_settings(
         Text of project file converted from markdown
     proj_data: dict
         Project settings
-    md: MetaMarkdown
-        Markdown converter
 
     """
 
@@ -300,15 +299,7 @@ def load_settings(
     if proj_data is None:
         proj_data, proj_docs = load_markdown_settings(directory, proj_docs)
 
-    # Setup Markdown object with any user-specified extensions
-    md = MetaMarkdown(
-        proj_data.md_base_dir or directory, extensions=proj_data.md_extensions
-    )
-
-    # Now re-read project file with all extensions loaded
-    proj_docs = md.reset().convert(proj_docs)
-
-    return proj_docs, proj_data, md
+    return proj_docs, proj_data
 
 
 def parse_arguments(
@@ -399,7 +390,7 @@ def parse_arguments(
     return proj_data, proj_docs
 
 
-def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
+def main(proj_data: ProjectSettings, proj_docs: str):
     """
     Main driver of FORD.
     """
@@ -412,19 +403,18 @@ def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
         )
         sys.exit(1)
 
-    # Define core macros:
-    ford.utils.register_macro(f"url = {proj_data.project_url}")
-    ford.utils.register_macro(f'media = {os.path.join(proj_data.project_url, "media")}')
-    ford.utils.register_macro(f'page = {os.path.join(proj_data.project_url, "page")}')
-
-    # Register the user defined aliases:
-    for alias in proj_data.alias:
-        ford.utils.register_macro(alias)
-
-    # Convert the documentation from Markdown to HTML. Make sure to properly
-    # handle LateX and metadata.
     base_url = ".." if proj_data.relative else proj_data.project_url
     project.correlate()
+
+    # Setup Markdown object with any user-specified extensions
+    aliases = copy.copy(proj_data.alias)
+    aliases.update(proj_data.external)
+    md = MetaMarkdown(
+        proj_data.md_base_dir, extensions=proj_data.md_extensions, aliases=aliases
+    )
+
+    # Convert the documentation from Markdown to HTML
+    proj_docs = md.reset().convert(proj_docs)
     project.markdown(md, base_url)
     project.make_links(base_url)
 
@@ -433,16 +423,14 @@ def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
         ford.sourceform.set_base_url(".")
     if proj_data.summary is not None:
         proj_data.summary = md.convert(proj_data.summary)
-        proj_data.summary = ford.utils.sub_links(
-            ford.utils.sub_macros(proj_data.summary), project
-        )
+        proj_data.summary = ford.utils.sub_links(proj_data.summary, project)
     if proj_data.author_description is not None:
         proj_data.author_description = md.convert(proj_data.author_description)
         proj_data.author_description = ford.utils.sub_links(
-            ford.utils.sub_macros(proj_data.author_description),
+            proj_data.author_description,
             project,
         )
-    proj_docs_ = ford.utils.sub_links(ford.utils.sub_macros(proj_docs), project)
+    proj_docs_ = ford.utils.sub_links(proj_docs, project)
     # Process any pages
     if proj_data.page_dir is not None:
         page_tree = get_page_tree(
@@ -471,11 +459,11 @@ def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
 
 
 def run():
-    proj_data, proj_docs, md = initialize()
+    proj_data, proj_docs = initialize()
 
     f = StringIO() if proj_data.quiet else sys.stdout
     with stdout_redirector(f):
-        main(proj_data, proj_docs, md)
+        main(proj_data, proj_docs)
 
 
 if __name__ == "__main__":

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -403,8 +403,7 @@ def main(proj_data: ProjectSettings, proj_docs: str, md: MetaMarkdown):
     """
     Main driver of FORD.
     """
-    if proj_data.relative:
-        proj_data.project_url = "."
+
     # Parse the files in your project
     project = ford.fortran_project.Project(proj_data)
     if len(project.files) < 1:

--- a/ford/_markdown.py
+++ b/ford/_markdown.py
@@ -1,5 +1,7 @@
 from markdown import Markdown, Extension
+from markdown.inlinepatterns import InlineProcessor
 from typing import Dict, List, Union, Optional
+import re
 
 from ford.md_environ import EnvironExtension
 from ford.md_admonition import AdmonitionExtension
@@ -14,6 +16,7 @@ class MetaMarkdown(Markdown):
         md_base: PathLike = ".",
         extensions: Optional[List[Union[str, Extension]]] = None,
         extension_configs: Optional[Dict[str, Dict]] = None,
+        aliases: Optional[Dict[str, str]] = None,
     ):
         default_extensions: List[Union[str, Extension]] = [
             "markdown_include.include",
@@ -23,6 +26,10 @@ class MetaMarkdown(Markdown):
             EnvironExtension(),
             AdmonitionExtension(),
         ]
+
+        if aliases is not None:
+            default_extensions.append(AliasExtension(aliases=aliases))
+
         if extensions is None:
             extensions = []
 
@@ -33,4 +40,38 @@ class MetaMarkdown(Markdown):
             extensions=default_extensions + extensions,
             output_format="html",
             extension_configs=default_config,
+        )
+
+
+ALIAS_RE = r"\|(.+?)\|"
+
+
+class AliasProcessor(InlineProcessor):
+    """Substitute text aliases of the form ``|foo|`` from a dictionary
+    of aliases and their replacements"""
+
+    def __init__(self, pattern: str, md: Markdown, aliases: Dict[str, str]):
+        self.aliases = aliases
+        super().__init__(pattern, md)
+
+    def handleMatch(self, m: re.Match, data: str):  # type: ignore[override]
+        try:
+            sub = self.aliases[m.group(1)]
+        except KeyError:
+            return None, None, None
+
+        return sub, m.start(0), m.end(0)
+
+
+class AliasExtension(Extension):
+    """Markdown extension to register `AliasProcessor`"""
+
+    def __init__(self, **kwargs):
+        self.config = {"aliases": [{}, "List of aliases"]}
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md: Markdown):
+        aliases = self.getConfig("aliases")
+        md.inlinePatterns.register(
+            AliasProcessor(ALIAS_RE, md, aliases=aliases), "ford_aliases", 175
         )

--- a/ford/external_project.py
+++ b/ford/external_project.py
@@ -18,7 +18,6 @@ from ford.sourceform import (
     ExternalVariable,
     ExternalBoundProcedure,
 )
-from ford.utils import register_macro
 from ford.version import __version__
 
 
@@ -162,9 +161,7 @@ def load_external_modules(project):
     """Load external modules from JSON file into an existing project"""
 
     # get the external modules from the external URLs
-    for urldef in project.external:
-        # get the external modules from the external URL
-        url, short = register_macro(urldef)
+    for url in project.external.values():
         remote = re.match("https?://", url)
         try:
             if remote:

--- a/ford/output.py
+++ b/ford/output.py
@@ -539,7 +539,7 @@ class PagetreePage(BasePage):
             ford.pagetree.set_base_url(base_url)
             data["project_url"] = base_url
         template = env.get_template("info_page.html")
-        obj.contents = ford.utils.sub_links(ford.utils.sub_macros(obj.contents), proj)
+        obj.contents = ford.utils.sub_links(obj.contents, proj)
         return template.render(data, page=obj, project=proj, topnode=obj.topnode)
 
     def writeout(self):

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -127,7 +127,7 @@ class ProjectSettings:
     macro: list = field(default_factory=list)
     mathjax_config: Optional[Path] = None
     max_frontpage_items: int = 10
-    md_base_dir: Optional[Path] = None
+    md_base_dir: Path = Path(".")
     md_extensions: list = field(default_factory=list)
     media_dir: Optional[Path] = None
     output_dir: Path = Path("./doc")
@@ -204,6 +204,9 @@ class ProjectSettings:
         if self.favicon == FAVICON_PATH:
             self.favicon = Path(__file__).parent / FAVICON_PATH
 
+        if self.md_base_dir == Path("."):
+            self.md_base_dir = directory
+
         for key, value in asdict(self).items():
             if value is None:
                 continue
@@ -216,9 +219,6 @@ class ProjectSettings:
 
             if is_same_type(default_type, Path):
                 setattr(self, key, normalise_path(directory, value))
-
-        if self.md_base_dir is None:
-            self.md_base_dir = directory
 
 
 def load_toml_settings(directory: PathLike) -> Optional[ProjectSettings]:

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -181,6 +181,9 @@ class ProjectSettings:
         self.display = [item.lower() for item in self.display]
         self.extensions = list(set(self.extensions) | set(self.fpp_extensions))
 
+        if self.relative:
+            self.project_url = "."
+
         # Check that none of the docmarks are the same
         docmarks = ["docmark", "predocmark", "docmark_alt", "predocmark_alt"]
         for first, second in combinations(docmarks, 2):

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -184,6 +184,16 @@ class ProjectSettings:
         if self.relative:
             self.project_url = "."
 
+        # Define some core macros
+        url_path = Path(self.project_url)
+        self.alias.update(
+            {
+                "url": self.project_url,
+                "media": str(url_path / "media"),
+                "page": str(url_path / "page"),
+            }
+        )
+
         # Check that none of the docmarks are the same
         docmarks = ["docmark", "predocmark", "docmark_alt", "predocmark_alt"]
         for first, second in combinations(docmarks, 2):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -367,11 +367,9 @@ class FortranBase:
         # Remove any common leading whitespace from the docstring
         # so that the markdown conversion is a bit more robust
         self.doc = md.reset().convert(textwrap.dedent("\n".join(self.doc_list)))
-        self.doc = ford.utils.sub_macros(self.doc)
 
         if self.meta.summary is not None:
             self.meta.summary = md.convert("\n".join(self.meta.summary))
-            self.meta.summary = ford.utils.sub_macros(self.meta.summary)
         elif paragraph := PARA_CAPTURE_RE.search(self.doc):
             # If there is no stand-alone webpage for this item, e.g.
             # an internal routine, make the whole doc blob appear,

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -38,12 +38,6 @@ if TYPE_CHECKING:
 LINK_RE = re.compile(r"\[\[(\w+(?:\.\w+)?)(?:\((\w+)\))?(?::(\w+)(?:\((\w+)\))?)?\]\]")
 
 
-# Dictionary for all macro definitions to be used in the documentation.
-# Each key of the form |name| will be replaced by the value found in the
-# dictionary in sub_macros.
-_MACRO_DICT: Dict[str, str] = {}
-
-
 def get_parens(line: str, retlevel: int = 0, retblevel: int = 0) -> str:
     """
     By default takes a string starting with an open parenthesis and returns the portion
@@ -307,48 +301,6 @@ def sub_links(string: str, project: Project) -> str:
 
     # Get information from links (need to build an RE)
     string = LINK_RE.sub(convert_link, string)
-    return string
-
-
-def register_macro(string):
-    """Register a new macro definition of the form ``key = value``.
-    In the documentation ``|key|`` can then be used to represent value.
-    If key is already defined in the list of macros an `RuntimeError`
-    will be raised.
-
-    The function returns a tuple of the form ``(value, key)``, where
-    key is ``None`` if no key definition is found in the string.
-
-    """
-
-    if "=" not in string:
-        raise RuntimeError(f"Error, no alias name provided for {string}")
-
-    chunks = string.split("=", 1)
-    key = f"|{chunks[0].strip()}|"
-    val = chunks[1].strip()
-
-    if key in _MACRO_DICT and val != _MACRO_DICT[key]:
-        # The macro is already defined. Do not overwrite it!
-        # Can be ignored if the definition is the same...
-        raise RuntimeError(
-            f'Could not register macro "{key}" as "{val}"'
-            f'because it is already defined as "{_MACRO_DICT[key]}"'
-        )
-
-    # Everything OK, add the macro definition to the dict.
-    _MACRO_DICT[key] = val
-
-    return (val, key)
-
-
-def sub_macros(string):
-    """
-    Replaces macros in documentation with their appropriate values. These macros
-    are used for things like providing URLs.
-    """
-    for key, val in _MACRO_DICT.items():
-        string = string.replace(key, val)
     return string
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,13 +31,6 @@ def copy_settings_file(tmp_path):
 
 
 @pytest.fixture
-def restore_macros():
-    old_macros = copy.copy(ford.utils._MACRO_DICT)
-    yield
-    ford.utils._MACRO_DICT = copy.copy(old_macros)
-
-
-@pytest.fixture
 def restore_nameselector():
     yield
     ford.sourceform.namelist = ford.sourceform.NameSelector()

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -35,7 +35,7 @@ def example_project(tmp_path_factory):
     with open(tmp_path / "example-project-file.md", "r") as f:
         project_file = f.read()
 
-    project_file, project_settings, _ = ford.load_settings(project_file)
+    project_file, project_settings = ford.load_settings(project_file)
     settings, _ = ford.parse_arguments({}, project_file, project_settings, tmp_path)
 
     doc_path = tmp_path / "doc"

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -14,9 +14,9 @@ class FakeFile:
 
 
 def test_quiet_false():
-    _, data, _ = ford.load_settings("quiet: False")
+    _, data = ford.load_settings("quiet: False")
     assert data.quiet is False
-    _, data2, _ = ford.load_settings("quiet: True")
+    _, data2 = ford.load_settings("quiet: True")
     assert data2.quiet is True
 
 
@@ -33,7 +33,7 @@ def test_toml(tmp_path):
     }
     settings_file.write_text(tomli_w.dumps(settings))
 
-    _, data, _ = ford.load_settings("", tmp_path)
+    _, data = ford.load_settings("", tmp_path)
 
     assert data.quiet is True
     assert data.display[0] == "public"
@@ -65,7 +65,7 @@ def test_list_input():
              one
              string
     """
-    _, data, _ = ford.load_settings(dedent(settings))
+    _, data = ford.load_settings(dedent(settings))
 
     assert len(data.include) == 2
     assert data.summary == "This\nis\none\nstring"
@@ -188,13 +188,13 @@ def test_absolute_src_dir(monkeypatch, tmp_path):
 
     with monkeypatch.context() as m:
         m.setattr(sys, "argv", ["ford", str(project_file)])
-        args, _, _ = ford.initialize()
+        args, _ = ford.initialize()
 
     assert args.src_dir == [tmp_path / "./src"]
 
     with monkeypatch.context() as m:
         m.setattr(sys, "argv", ["ford", str(project_file), "--src_dir", str(src_dir)])
-        args, _, _ = ford.initialize()
+        args, _ = ford.initialize()
 
     assert args.src_dir == [src_dir]
 
@@ -202,7 +202,7 @@ def test_absolute_src_dir(monkeypatch, tmp_path):
         m.setattr(
             sys, "argv", ["ford", "--src_dir", str(src_dir), "--", str(project_file)]
         )
-        args, _, _ = ford.initialize()
+        args, _ = ford.initialize()
 
     assert args.src_dir == [src_dir]
 
@@ -213,7 +213,7 @@ def test_output_dir_cli(monkeypatch, tmp_path):
 
     with monkeypatch.context() as m:
         m.setattr(sys, "argv", ["ford", str(project_file), "--output_dir", "something"])
-        settings, _, _ = ford.initialize()
+        settings, _ = ford.initialize()
 
     assert settings.output_dir == tmp_path / "something"
 
@@ -222,6 +222,6 @@ def test_output_dir_cli(monkeypatch, tmp_path):
 
     with monkeypatch.context() as m:
         m.setattr(sys, "argv", ["ford", str(project_file)])
-        settings, _, _ = ford.initialize()
+        settings, _ = ford.initialize()
 
     assert settings.output_dir == tmp_path / "something_else"

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -1,0 +1,13 @@
+from ford._markdown import MetaMarkdown
+
+
+def test_sub_alias():
+    result = MetaMarkdown(aliases={"a": "b"}).convert("|a|")
+
+    assert result == "<p>b</p>"
+
+
+def test_sub_alias_with_equals():
+    result = MetaMarkdown(aliases={"a": "b=c"}).convert("|a|")
+
+    assert result == "<p>b=c</p>"

--- a/test/test_md_inputs.py
+++ b/test/test_md_inputs.py
@@ -27,7 +27,6 @@ def test_extra_mods_empty(
     copy_fortran_file,
     copy_settings_file,
     monkeypatch,
-    restore_macros,
     restore_nameselector,
 ):
     """This checks that extra_mods is parsed correctly in input md file"""
@@ -52,7 +51,6 @@ def test_extra_mods_intrinsic(
     copy_fortran_file,
     copy_settings_file,
     monkeypatch,
-    restore_macros,
     restore_nameselector,
 ):
     """This checks that adding extra_mods doesn't change the module variable INTRINSIC_MODS"""
@@ -89,7 +87,6 @@ def test_default_aliases(
     copy_settings_file,
     tmp_path,
     monkeypatch,
-    restore_macros,
     restore_nameselector,
 ):
     """Check that aliases specified in project file are replaced correctly"""
@@ -113,7 +110,7 @@ def test_default_aliases(
 
     html_dir = tmp_path / "doc"
     index_text = get_main_body_text(html_dir, "index.html")
-    media_dir = os.path.join(".", "media")
+    media_dir = pathlib.Path("./media")
     expected_index_text = [
         f"Test: The project media url should be {media_dir}",
     ]
@@ -131,7 +128,6 @@ def test_one_alias(
     copy_settings_file,
     tmp_path,
     monkeypatch,
-    restore_macros,
     restore_nameselector,
 ):
     """Check that aliases specified in project file are replaced correctly"""
@@ -181,7 +177,6 @@ def test_multiple_aliases(
     copy_settings_file,
     tmp_path,
     monkeypatch,
-    restore_macros,
     restore_nameselector,
 ):
     """Check that aliases specified in project file are replaced correctly"""

--- a/test/test_projects/test_external_project.py
+++ b/test/test_projects/test_external_project.py
@@ -73,17 +73,7 @@ def monkeymodule(request):
 
 
 @pytest.fixture(scope="module")
-def restore_macros_module():
-    """pytest won't let us use function-scope fixtures in module-scope
-    fixtures, so we need to reimplement this with module scope"""
-
-    old_macros = copy.copy(ford.utils._MACRO_DICT)
-    yield
-    ford.utils._MACRO_DICT = copy.copy(old_macros)
-
-
-@pytest.fixture(scope="module")
-def external_project(tmp_path_factory, monkeymodule, restore_macros_module):
+def external_project(tmp_path_factory, monkeymodule):
     """Generate the documentation for an "external" project and then
     for a "top level" one that uses the first.
 

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -56,7 +56,13 @@ def test_settings_type_conversion_from_markdown():
     assert settings.summary == "first\nsecond"
     assert settings.preprocess is True
     assert settings.max_frontpage_items == 4
-    assert settings.alias == {"a": "b", "c": "d"}
+    assert settings.alias == {
+        "a": "b",
+        "c": "d",
+        "url": ".",
+        "media": "media",
+        "page": "page",
+    }
 
 
 def test_entity_settings_from_project():

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -43,6 +43,8 @@ def test_settings_type_conversion_from_markdown():
             fpp_extensions: fpp
                             F90
             max_frontpage_items: 4
+            alias: a = b
+                c = d
             ---
             """
         ),
@@ -54,6 +56,7 @@ def test_settings_type_conversion_from_markdown():
     assert settings.summary == "first\nsecond"
     assert settings.preprocess is True
     assert settings.max_frontpage_items == 4
+    assert settings.alias == {"a": "b", "c": "d"}
 
 
 def test_entity_settings_from_project():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,30 +4,6 @@ import ford
 from ford.utils import meta_preprocessor
 
 
-def test_sub_macro(restore_macros):
-    ford.utils.register_macro("a=b")
-    result = ford.utils.sub_macros("|a|")
-
-    assert result == "b"
-
-
-def test_sub_macro_with_equals(restore_macros):
-    ford.utils.register_macro("a=b=c")
-    result = ford.utils.sub_macros("|a|")
-
-    assert result == "b=c"
-
-
-def test_register_macro_clash(restore_macros):
-    ford.utils.register_macro("a=b")
-
-    # Should be ok registering the same key-value pair again
-    ford.utils.register_macro("a=b")
-
-    with pytest.raises(RuntimeError):
-        ford.utils.register_macro("a=c")
-
-
 @pytest.mark.parametrize("string", ["true", "True", "TRUE", "tRuE"])
 def test_str_to_bool_true(string):
     assert ford.utils.str_to_bool(string)


### PR DESCRIPTION
This simplifies the markdown conversion a little by moving the alias substitution inside the `Markdown.convert` call.

Also move creation of the markdown object to as late as possible so that we can set the aliases from the settings object.

One downside to this approach is that it's no longer possible to detect duplicate aliases.