### PR TITLE
Convert `sub_links` to markdown extension

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -410,27 +410,24 @@ def main(proj_data: ProjectSettings, proj_docs: str):
     aliases = copy.copy(proj_data.alias)
     aliases.update(proj_data.external)
     md = MetaMarkdown(
-        proj_data.md_base_dir, extensions=proj_data.md_extensions, aliases=aliases
+        proj_data.md_base_dir,
+        extensions=proj_data.md_extensions,
+        aliases=aliases,
+        project=project,
     )
 
     # Convert the documentation from Markdown to HTML
     proj_docs = md.reset().convert(proj_docs)
     project.markdown(md, base_url)
-    project.make_links(base_url)
 
     # Convert summaries and descriptions to HTML
     if proj_data.relative:
         ford.sourceform.set_base_url(".")
     if proj_data.summary is not None:
         proj_data.summary = md.convert(proj_data.summary)
-        proj_data.summary = ford.utils.sub_links(proj_data.summary, project)
     if proj_data.author_description is not None:
         proj_data.author_description = md.convert(proj_data.author_description)
-        proj_data.author_description = ford.utils.sub_links(
-            proj_data.author_description,
-            project,
-        )
-    proj_docs_ = ford.utils.sub_links(proj_docs, project)
+
     # Process any pages
     if proj_data.page_dir is not None:
         page_tree = get_page_tree(
@@ -447,7 +444,7 @@ def main(proj_data: ProjectSettings, proj_docs: str):
     # and copy any files that are needed (CSS, JS, images, fonts, source files,
     # etc.)
 
-    docs = ford.output.Documentation(proj_data, proj_docs_, project, page_tree)
+    docs = ford.output.Documentation(proj_data, proj_docs, project, page_tree)
     docs.writeout()
 
     if proj_data.externalize:

--- a/ford/_markdown.py
+++ b/ford/_markdown.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 from markdown import Markdown, Extension
 from markdown.inlinepatterns import InlineProcessor
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, TYPE_CHECKING
 import re
+from xml.etree.ElementTree import Element
 
 from ford.md_environ import EnvironExtension
 from ford.md_admonition import AdmonitionExtension
 from ford._typing import PathLike
+
+if TYPE_CHECKING:
+    from ford.fortran_project import Project
 
 
 class MetaMarkdown(Markdown):
@@ -17,6 +23,7 @@ class MetaMarkdown(Markdown):
         extensions: Optional[List[Union[str, Extension]]] = None,
         extension_configs: Optional[Dict[str, Dict]] = None,
         aliases: Optional[Dict[str, str]] = None,
+        project=None,
     ):
         default_extensions: List[Union[str, Extension]] = [
             "markdown_include.include",
@@ -29,6 +36,9 @@ class MetaMarkdown(Markdown):
 
         if aliases is not None:
             default_extensions.append(AliasExtension(aliases=aliases))
+
+        if project is not None:
+            default_extensions.append(FordLinkExtension(project=project))
 
         if extensions is None:
             extensions = []
@@ -74,4 +84,73 @@ class AliasExtension(Extension):
         aliases = self.getConfig("aliases")
         md.inlinePatterns.register(
             AliasProcessor(ALIAS_RE, md, aliases=aliases), "ford_aliases", 175
+        )
+
+
+class FordLinkProcessor(InlineProcessor):
+    """Replace links to different parts of the program, formatted as
+    [[name]] or [[name(object-type)]] with the appropriate URL. Can
+    also link to an item's entry in another's page with the syntax
+    [[parent-name:name]]. The object type can be placed in parentheses
+    for either or both of these parts.
+
+    """
+
+    LINK_RE = re.compile(
+        r"""\[\[
+        (?P<name>\w+(?:\.\w+)?)
+        (?:\((?P<entity>\w+)\))?
+        (?::(?P<child_name>\w+)
+        (?:\((?P<child_entity>\w+)\))?)?
+        \]\]""",
+        re.VERBOSE | re.UNICODE,
+    )
+
+    def __init__(self, md: Markdown, project: Project):  # type: ignore[overrider]
+        self.project = project
+        self.md = md
+
+    def getCompiledRegExp(self):
+        return self.LINK_RE
+
+    def convert_link(self, m: re.Match):
+        item = self.project.find(**m.groupdict())
+
+        # Could resolve full parent::child, so just try to find parent instead
+        if m["child_name"] and item is None:
+            parent_name = m["name"]
+            print(
+                f"Warning: Could not substitute link {m.group()}. "
+                f'"{m["child_name"]}" not found in "{parent_name}", linking to page for "{parent_name}" instead'
+            )
+            item = self.project.find(m["name"], m["entity"])
+
+        link = Element("a")
+
+        # Nothing found, so give a blank link
+        if item is None:
+            name = m["name"]
+            print(f"Warning: Could not substitute link {m.group()}. '{name}' not found")
+            link.text = name
+            return link
+
+        link.attrib["href"] = item.get_url()
+        link.text = item.name
+        return link
+
+    def handleMatch(self, m: re.Match, data: str):  # type: ignore[override]
+        return self.convert_link(m), m.start(0), m.end(0)
+
+
+class FordLinkExtension(Extension):
+    """Markdown extension to register `FordLinkProcessor`"""
+
+    def __init__(self, **kwargs):
+        self.config = {"project": [kwargs.get("project", None), "Ford project"]}
+        super().__init__(**kwargs)
+
+    def extendMarkdown(self, md: Markdown):
+        project = self.getConfig("project")
+        md.inlinePatterns.register(
+            FordLinkProcessor(md, project=project), "ford_links", 174
         )

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -118,15 +118,13 @@ class Project:
                     else:
                         preprocessor = None
                     try:
-                        self.files.append(
-                            ford.sourceform.FortranSourceFile(
-                                str(filename),
-                                settings,
-                                preprocessor,
-                                extension in self.fixed_extensions,
-                                incl_src=html_incl_src,
-                                encoding=self.encoding,
-                            )
+                        new_file = ford.sourceform.FortranSourceFile(
+                            str(filename),
+                            settings,
+                            preprocessor,
+                            extension in self.fixed_extensions,
+                            incl_src=html_incl_src,
+                            encoding=self.encoding,
                         )
                     except Exception as e:
                         if not settings.dbg:
@@ -138,30 +136,37 @@ class Project:
                     def namelist_check(entity):
                         self.namelists.extend(getattr(entity, "namelists", []))
 
-                    for module in self.files[-1].modules:
+                    for module in new_file.modules:
                         self.modules.append(module)
                         for routine in module.routines:
                             namelist_check(routine)
-                    for submod in self.files[-1].submodules:
+
+                    for submod in new_file.submodules:
                         self.submodules.append(submod)
                         for routine in submod.routines:
                             namelist_check(routine)
-                    for function in self.files[-1].functions:
+
+                    for function in new_file.functions:
                         function.visible = True
                         self.procedures.append(function)
                         namelist_check(function)
-                    for subroutine in self.files[-1].subroutines:
+
+                    for subroutine in new_file.subroutines:
                         subroutine.visible = True
                         self.procedures.append(subroutine)
                         namelist_check(subroutine)
-                    for program in self.files[-1].programs:
+
+                    for program in new_file.programs:
                         program.visible = True
                         self.programs.append(program)
                         namelist_check(program)
                         for routine in program.routines:
                             namelist_check(routine)
-                    for block in self.files[-1].blockdata:
+
+                    for block in new_file.blockdata:
                         self.blockdata.append(block)
+
+                    self.files.append(new_file)
                 elif extension in self.extra_filetypes:
                     print(f"Reading file {relative_path}")
                     try:

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -398,15 +398,6 @@ class Project:
         for src in self.allfiles:
             src.markdown(md, self)
 
-    def make_links(self, base_url=".."):
-        """
-        Substitute intrasite links to documentation for other parts of
-        the program.
-        """
-        ford.sourceform.set_base_url(base_url)
-        for src in self.allfiles:
-            src.make_links(self)
-
     def make_srcdir_list(self, exclude_dirs):
         """
         Like `os.walk`, except that:

--- a/ford/output.py
+++ b/ford/output.py
@@ -539,7 +539,6 @@ class PagetreePage(BasePage):
             ford.pagetree.set_base_url(base_url)
             data["project_url"] = base_url
         template = env.get_template("info_page.html")
-        obj.contents = ford.utils.sub_links(obj.contents, proj)
         return template.render(data, page=obj, project=proj, topnode=obj.topnode)
 
     def writeout(self):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -461,19 +461,6 @@ class FortranBase:
             entity = getattr(self, entities, [])
             entity.sort(key=sort_key)
 
-    def make_links(self, project: Project) -> None:
-        """
-        Process intra-site links to documentation of other parts of the program.
-        """
-        self.doc = ford.utils.sub_links(self.doc, project)
-        if self.meta.summary is not None:
-            self.meta.summary = ford.utils.sub_links(self.meta.summary, project)
-
-        # Create links in the project
-        for item in self.children:
-            if isinstance(item, FortranBase) and hasattr(item, "doc"):
-                item.make_links(project)
-
     @property
     def routines(self):
         """Iterator returning all procedures"""

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -22,28 +22,13 @@
 #
 #
 
-from __future__ import annotations
-
 import re
 import os.path
 import pathlib
-from typing import Dict, Union, TYPE_CHECKING, List, Any, Tuple
+from typing import Dict, Union, List, Any, Tuple
 from io import StringIO
 import itertools
 from collections import defaultdict
-
-if TYPE_CHECKING:
-    from ford.fortran_project import Project
-
-LINK_RE = re.compile(
-    r"""\[\[
-    (?P<name>\w+(?:\.\w+)?)
-    (?:\((?P<entity>\w+)\))?
-    (?::(?P<child_name>\w+)
-    (?:\((?P<child_entity>\w+)\))?)?
-    \]\]""",
-    re.VERBOSE,
-)
 
 
 def get_parens(line: str, retlevel: int = 0, retblevel: int = 0) -> str:
@@ -170,41 +155,6 @@ def quote_split(sep, string):
         i += 1
     retlist.append(string[left:])
     return retlist
-
-
-def sub_links(string: str, project: Project) -> str:
-    """
-    Replace links to different parts of the program, formatted as
-    [[name]] or [[name(object-type)]] with the appropriate URL. Can also
-    link to an item's entry in another's page with the syntax
-    [[parent-name:name]]. The object type can be placed in parentheses
-    for either or both of these parts.
-    """
-
-    def convert_link(match):
-        item = project.find(**match.groupdict())
-
-        # Could resolve full parent::child, so just try to find parent instead
-        if match["child_name"] and item is None:
-            parent_name = match["name"]
-            print(
-                f"Warning: Could not substitute link {match.group()}. "
-                f'"{match["child_name"]}" not found in "{parent_name}", linking to page for "{parent_name}" instead'
-            )
-            item = project.find(match["name"], match["entity"])
-
-        # Nothing found, so give a blank link
-        if item is None:
-            print(
-                f"Warning: Could not substitute link {match.group()}. '{match['name']}' not found"
-            )
-            return f"<a>{match['name']}</a>"
-
-        return f'<a href="{item.get_url()}">{item.name}</a>'
-
-    # Get information from links (need to build an RE)
-    string = LINK_RE.sub(convert_link, string)
-    return string
 
 
 def str_to_bool(text):

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -7,11 +7,10 @@ from ford.sourceform import (
     FortranSubroutine,
     FortranModule,
 )
+from ford._markdown import MetaMarkdown
 
 from itertools import chain
 
-
-import markdown
 import pytest
 from bs4 import BeautifulSoup
 
@@ -29,18 +28,8 @@ def copy_fortran_file(tmp_path):
     return copy_file
 
 
-def create_project(settings: dict):
-    md_ext = [
-        "markdown.extensions.meta",
-        "markdown.extensions.codehilite",
-        "markdown.extensions.extra",
-    ]
-    md = markdown.Markdown(
-        extensions=md_ext, output_format="html", extension_configs={}
-    )
-
+def create_project(settings: ProjectSettings):
     project = Project(settings)
-    project.markdown(md, "..")
     project.correlate()
     return project
 
@@ -1046,8 +1035,8 @@ def test_make_links(copy_fortran_file):
     """
     settings = copy_fortran_file(data)
     project = create_project(settings)
-
-    project.make_links()
+    md = MetaMarkdown(project=project)
+    project.markdown(md, "..")
 
     expected_links = {
         "a": "../module/a.html",


### PR DESCRIPTION
Closes #357 
Fixes #309 

Substitute Ford links via a markdown extension. This means all markdown processing can be done in a single call to `markdown.convert()`.