### PR TITLE
Fix bugs in new admonitions

### DIFF
--- a/ford/md_admonition.py
+++ b/ford/md_admonition.py
@@ -84,25 +84,17 @@ class FordAdmonitionProcessor(AdmonitionProcessor):
 
     CLASSNAME = "alert"
     CLASSNAME_TITLE = "alert-title h4"
-    RE = re.compile(
-        r"""(?:^|\n)@note ?(?P<klass>[\w\-]+(?: +[\w\-]+)*)(?: +"(?P<title>.*?)")? *(?:\n|$)"""
-    )
+    RE = re.compile(r"""(?:^|\n)@note ?(?P<klass>[\w\-]+) *(?:\n|$)""")
 
     def get_class_and_title(self, match):
         """Get the CSS class and title for this admonition
 
-        Title defaults to the note class, while the CSS class is looked up
+        Title is the note class, while the CSS class is looked up
         in the list of note types (`ADMONITION_TYPE`)
 
         """
-        css, title = super().get_class_and_title(match)
-        if len(css_bits := css.split()) > 1:
-            klass = css_bits[0]
-            more_css = " ".join(css_bits[1:])
-        else:
-            klass = css
-            more_css = ""
-        return f"alert-{ADMONITION_TYPE[klass]} {more_css}", title
+        klass = match["klass"].lower()
+        return f"alert-{ADMONITION_TYPE[klass]}", klass.capitalize()
 
 
 class AdmonitionPreprocessor(Preprocessor):
@@ -130,7 +122,6 @@ class AdmonitionPreprocessor(Preprocessor):
     ADMONITION_RE: ClassVar[re.Pattern] = re.compile(
         rf"""(?P<indent>\s*)
         @(?P<type>{"|".join(ADMONITION_TYPE.keys())})
-        (?P<extra>(?:\ +[\w\-]+)*\ +".*")?\s*
         (?P<posttxt>.*)
         """,
         re.IGNORECASE | re.VERBOSE,
@@ -244,8 +235,7 @@ class AdmonitionPreprocessor(Preprocessor):
                 # Something has gone seriously wrong!
                 raise FordMarkdownError("Missing start of @note", idx, lines, 0, -1)
 
-            extra = match["extra"] or ""
-            lines[idx] = f"{match['indent']}@note {admonition.type.capitalize()}{extra}"
+            lines[idx] = f"{match['indent']}@note {admonition.type.capitalize()}"
             if posttxt := match["posttxt"]:
                 lines.insert(idx + 1, self.INDENT + match["indent"] + posttxt)
 

--- a/test/test_md_admonition.py
+++ b/test/test_md_admonition.py
@@ -86,6 +86,7 @@ def test_paragraph_end_line():
     assert soup.find(class_="h4").text == "Note"
     assert soup.div.find(not_title).text == "note text\nsome following text"
 
+
 def test_explicit_end():
     converted = convert(
         """
@@ -261,29 +262,14 @@ def test_midparagraph():
 def test_title():
     converted = convert(
         """
-        @note "title" text
-        """
+        @warning some "title" text
+        over multiple lines"""
     )
 
     soup = BeautifulSoup(converted, features="html.parser")
     assert len(soup) == 1
-    assert sorted(soup.div["class"]) == ["alert", "alert-info"]
-    assert soup.find(class_="h4").text == "title"
-    assert soup.div.find(not_title).text == "text"
-
-
-def test_css_and_title():
-    converted = convert(
-        """
-        @note some css "title" text
-        """
-    )
-
-    soup = BeautifulSoup(converted, features="html.parser")
-    assert len(soup) == 1
-    assert sorted(soup.div["class"]) == sorted(["alert", "alert-info", "some", "css"])
-    assert soup.find(class_="h4").text == "title"
-    assert soup.div.find(not_title).text == "text"
+    assert sorted(soup.div["class"]) == ["alert", "alert-warning"]
+    assert soup.div.find(not_title).text == 'some "title" text\nover multiple lines'
 
 
 def test_end_marker_without_start():


### PR DESCRIPTION
Fixes #544 

- If an admonition is closed by the end of the docstring, make sure the last line is included
- Insert a blank line between the end of the admonition and any trailing text
- Don't allow custom css/title in admonitions, this clashes too much with existing usage