### PR TITLE
Improve `exclude` and `exclude_dir` options

### DIFF
--- a/docs/user_guide/project_file_options.rst
+++ b/docs/user_guide/project_file_options.rst
@@ -314,7 +314,9 @@ exclude_dir
 
 Directories whose contents should not be included in documentation. Each
 excluded directory must be on its own line. Provide the relative path to
-directory from the top level project file.
+directory from the top level project file. Can be a glob pattern, for example
+``**/test*``, which will match any directory that starts with ``test``
+anywhere in the source directory tree.
 
 .. _option-include:
 
@@ -380,8 +382,17 @@ exclude
 ^^^^^^^
 
 Source files which should not be included in documentation. Each
-excluded file must be on its own line. Provide only the file-name, not
-the full path.
+excluded file must be on its own line. This should either be a relative path
+that includes one of the source directories, or a glob pattern. For example,
+``src/not_this.f90`` to exclude a specific file, or ``**/test_*.f90`` to
+exclude any ``.f90`` files that start with ``test_`` anywhere in any of the
+source directories.
+
+.. deprecated:: 7.0.0
+   In earlier versions, ``not_this.f90`` would exclude any file called
+   ``not_this.f90`` anywhere in the project. This will now emit a warning,
+   and should be changed to either a relative path (``src/not_this.f90``) or
+   a glob pattern (``**/not_this.f90``)
 
 .. _option-extensions:
 

--- a/example/example-project-file.md
+++ b/example/example-project-file.md
@@ -26,7 +26,7 @@ extra_mods: json_module: http://jacobwilliams.github.io/json-fortran/
 license: by-nc
 extra_filetypes: sh #
 max_frontpage_items: 4
-exclude: excluded_file.f90
+exclude: src/excluded_file.f90
 exclude_dir: src/excluded_directory
 page_dir: pages
 ---

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -120,7 +120,12 @@ def find_all_files(settings: ProjectSettings) -> List[Path]:
     bottom_level_dirs = [src_dir.name for src_dir in settings.src_dir]
     # First, let's check if the files are relative paths or not
     for i, exclude in enumerate(settings.exclude):
-        if Path(exclude).parent.name not in bottom_level_dirs and "*" not in exclude:
+        exclude_path = Path(exclude)
+        if (
+            not exclude_path.is_file()
+            and exclude_path.parent.name not in bottom_level_dirs
+            and "*" not in exclude
+        ):
             glob_exclude = f"**/{exclude}"
             print(
                 f"Warning: exclude file '{exclude}' is not relative to any source directories, all matching files will be excluded.\n"

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -201,6 +201,7 @@ class ProjectSettings:
 
         self.display = [item.lower() for item in self.display]
         self.extensions = list(set(self.extensions) | set(self.fpp_extensions))
+        self.exclude_dir.append(self.output_dir)
 
         if self.relative:
             self.project_url = "."


### PR DESCRIPTION
- Allow glob patterns like `**/test_*.f90`
- Automatically exclude `output_dir`
- Fix `--exclude_dir` set on command line not overriding `src_dir`

Fixes #259 
Fixes #349 