### PR TITLE
Fix for docstrings on unnamed interface blocks

### DIFF
--- a/example/src/ford_test_module.fpp
+++ b/example/src/ford_test_module.fpp
@@ -2,8 +2,9 @@ module test_module
   implicit none
 
   interface
+    !! Docstring on the interface block itself
     module subroutine check()
-      !! Docstring on the interface
+      !! Docstring on the subroutine's interface
     end subroutine check
   end interface
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2176,6 +2176,12 @@ class FortranInterface(FortranContainer):
             contents.append(FortranModuleProcedureInterface(proc, self, self.doc_list))
         self.contents = contents
 
+    def get_dir(self) -> Optional[str]:
+        # Unnamed interfaces don't have separate pages
+        if self.name:
+            return super().get_dir()
+        return None
+
 
 class FortranModuleProcedureInterface(FortranInterface):
     """The interface part of a `FortranModuleProcedureImplementation`


### PR DESCRIPTION
Unnamed interface blocks don't get their own separate page, but checking `.get_dir()` would return a directory name when it should be `None`.