### PR TITLE
Switch default preprocessor to `pcpp`

### DIFF
--- a/docs/user_guide/project_file_options.rst
+++ b/docs/user_guide/project_file_options.rst
@@ -487,8 +487,7 @@ preprocessor
 The preproccessor command to use on files with extensions in `fpp_extensions
 <option-fpp_extensions>`. Can include flags as needed. Preprocessor macros and
 include paths specified in the project file will automatically be appended using
-the CPP interface, which is fairly standard. (*default*:
-``cpp -traditional-cpp -E -D__GFORTRAN__``)
+the CPP interface, which is fairly standard. (*default*: ``pcpp -D__GFORTRAN__``)
 
 Documentation Markers
 ---------------------

--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -104,9 +104,10 @@ parsing them for documentation. This behaviour can `be disabled
 <option-preprocess>` or `different extensions <option-fpp_extensions>`
 can be specified, if desired. Note that any syntax-highlighted source
 code which is displayed in the output will be shown in its
-non-preprocessed form. The default preprocessor is CPP in legacy mode
-(the same as used by gfortran), but arbitrary preprocessors may be
-specified.
+non-preprocessed form. The default preprocessor is `pcpp
+<https://github.com/ned14/pcpp>`_, which is a C preprocessor
+implemented in Python, but you can `customise this command
+<option-preprocessor>`.
 
 Markdown
 --------

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -157,7 +157,7 @@ class ProjectSettings:
     predocmark: str = ">"
     predocmark_alt: str = "|"
     preprocess: bool = True
-    preprocessor: str = "cpp -traditional-cpp -E -D__GFORTRAN__"
+    preprocessor: str = "pcpp -D__GFORTRAN__"
     print_creation_date: bool = False
     privacy_policy_url: Optional[str] = None
     proc_internals: bool = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
    "tqdm ~= 4.64.0",
    "tomli >= 1.1.0 ; python_version < '3.11'",
    "rich >= 12.0.0",
+   "pcpp >= 1.30",
 ]
 dynamic = ["version"]
 

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -10,9 +10,6 @@ import re
 
 import ford.reader as reader
 from ford.reader import _contains_unterminated_string
-import pytest
-
-from conftest import gfortran_is_not_installed
 
 RE_WHITE = re.compile(r"\s+")
 
@@ -168,9 +165,6 @@ def test_multiline_string(copy_fortran_file):
     assert lines == expected
 
 
-@pytest.mark.skipif(
-    gfortran_is_not_installed(), reason="Requires gfortran to be installed"
-)
 def test_preprocessor(copy_fortran_file):
     """Check some basic preprocessing is applied"""
 
@@ -184,18 +178,13 @@ def test_preprocessor(copy_fortran_file):
     lines = "\n".join(
         list(
             reader.FortranReader(
-                str(filename),
-                preprocessor=["cpp", "-traditional-cpp", "-E"],
-                macros=["SUB_NAME=foo"],
+                str(filename), preprocessor=["pcpp"], macros=["SUB_NAME=foo"]
             )
         )
     )
     assert "foo" in lines
 
 
-@pytest.mark.skipif(
-    gfortran_is_not_installed(), reason="Requires gfortran to be installed"
-)
 def test_preprocessor_warning(copy_fortran_file):
     """Check preprocessing is still done even if there are warnings"""
 
@@ -210,9 +199,7 @@ def test_preprocessor_warning(copy_fortran_file):
     lines = "\n".join(
         list(
             reader.FortranReader(
-                str(filename),
-                preprocessor=["cpp", "-traditional-cpp", "-E"],
-                macros=["SUB_NAME=foo"],
+                str(filename), preprocessor=["pcpp"], macros=["SUB_NAME=foo"]
             )
         )
     )


### PR DESCRIPTION
As this is a python package, we can install it by default, and so don't need to rely on `cpp` being installed on the host system

Fixes #567 

@bkmgit I tried your podman file locally with this change and it seems to work, but maybe you want to double check it too?