### PR TITLE
Better errors for missing objects

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -414,11 +414,11 @@ def main(proj_data: ProjectSettings, proj_docs: str):
 
     base_url = ".." if proj_data.relative else proj_data.project_url
 
-    print("  Correlating information from different parts of your project...", end="")
+    print("  Correlating information from different parts of your project...")
     correlate_time_start = time.time()
     project.correlate()
     correlate_time_end = time.time()
-    print(f" done in {correlate_time_end - correlate_time_start:5.3f}s")
+    print(f"  ...done in {correlate_time_end - correlate_time_start:5.3f}s")
 
     # Setup Markdown object with any user-specified extensions
     aliases = copy.copy(proj_data.alias)

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -238,10 +238,6 @@ class Project:
 
         self.files.append(new_file)
 
-    def warn(self, message):
-        if self.settings.warn:
-            warn(f"{message}")
-
     @property
     def allfiles(self):
         """Instead of duplicating files, it is much more efficient to create the itterator on the fly"""
@@ -298,14 +294,22 @@ class Project:
 
         for mod in self.submodules:
             if type(mod.ancestor_module) is not FortranModule:
-                self.warn(
-                    f"Could not identify ancestor MODULE of SUBMODULE '{mod.name}'. "
+                print("\n")
+                warn(
+                    f"Could not identify ancestor module ('{mod.ancestor_module}') of submodule '{mod.name}' "
+                    f"(in '{mod.filename}').\n"
+                    f"         This is usually because Ford hasn't found '{mod.ancestor_module}' "
+                    "in any of the source directories.\n"
                 )
                 continue
 
             if not isinstance(mod.parent_submodule, (FortranSubmodule, type(None))):
-                self.warn(
-                    f"Could not identify parent SUBMODULE of SUBMODULE '{mod.name}'"
+                print("\n")
+                warn(
+                    f"Could not identify parent submodule ('{mod.parent_submodule}') of submodule '{mod.name}' "
+                    f"(in '{mod.filename}').\n"
+                    f"         This is usually because Ford hasn't found '{mod.parent_submodule}' "
+                    "in any of the source directories.\n"
                 )
 
             mod.deplist = [

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -294,7 +294,6 @@ class Project:
 
         for mod in self.submodules:
             if type(mod.ancestor_module) is not FortranModule:
-                print("\n")
                 warn(
                     f"Could not identify ancestor module ('{mod.ancestor_module}') of submodule '{mod.name}' "
                     f"(in '{mod.filename}').\n"
@@ -304,7 +303,6 @@ class Project:
                 continue
 
             if not isinstance(mod.parent_submodule, (FortranSubmodule, type(None))):
-                print("\n")
                 warn(
                     f"Could not identify parent submodule ('{mod.parent_submodule}') of submodule '{mod.name}' "
                     f"(in '{mod.filename}').\n"

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1450,6 +1450,8 @@ class FortranCodeUnit(FortranContainer):
             # extended type
             extend_type = context
             while extend_type := getattr(extend_type, "extends", None):
+                if isinstance(extend_type, str):
+                    break
                 labels[extend_type.name.lower()] = extend_type
             # vars
             labels.update(getattr(context, "all_vars", {}))
@@ -1983,6 +1985,16 @@ class FortranType(FortranContainer):
         # Match variables as needed (recurse)
         for v in self.variables:
             v.correlate(project)
+
+        if self.extends and isinstance(self.extends, str):
+            warn(
+                f"Could not find base type ('{self.extends}') of derived type '{self.name}' "
+                f"(in '{self.filename}').\n"
+                f"         If '{self.extends}' is defined in an external module, you may be "
+                "able to tell Ford about its documentation\n"
+                "         with the `extra_mods` setting"
+            )
+
         # Get inherited public components
         inherited = [
             var

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -1584,6 +1584,7 @@ class FortranModule(FortranCodeUnit):
         self.private_list: List[str] = []
         self.protected_list: List[str] = []
         self.visible = True
+        self.deplist: List[FortranModule] = []
 
     def _cleanup(self):
         """Create list of all local procedures. Ones coming from other modules

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -23,6 +23,7 @@
 #
 
 import re
+import os
 import os.path
 import pathlib
 from types import TracebackType
@@ -301,6 +302,13 @@ class ProgressBar:
         else:
             self._total = total
 
+        # rich `Progress` breaks `pdb` and `breakpoint`, see:
+        # - https://github.com/Textualize/rich/issues/1053
+        # - https://github.com/Textualize/rich/issues/1465
+        # and maintainer seems uninterested in fixing. So, workaround
+        # by setting an env var to disable progress bar entirely
+        disable: bool = bool(os.environ.get("FORD_DEBUGGING", False))
+
         self._iterable = iterable
         self._progress = Progress(
             SpinnerColumn(),
@@ -312,6 +320,7 @@ class ProgressBar:
             TimeElapsedColumn(),
             TextColumn("{task.fields[current]}"),
             console=console,
+            disable=disable,
         )
 
         self._progress.start()

--- a/ford/utils.py
+++ b/ford/utils.py
@@ -26,7 +26,7 @@ import re
 import os.path
 import pathlib
 from types import TracebackType
-from typing import Dict, Union, List, Any, Tuple, Optional, Sequence, cast, Sized, Type
+from typing import Dict, Union, List, Any, Tuple, Optional, Iterable, cast, Sized, Type
 from io import StringIO
 import itertools
 from collections import defaultdict
@@ -293,7 +293,7 @@ class ProgressBar:
     def __init__(
         self,
         description: str,
-        iterable: Optional[Sequence] = None,
+        iterable: Optional[Iterable] = None,
         total: Optional[int] = None,
     ):
         if total is None and hasattr(iterable, "__len__"):


### PR DESCRIPTION
Fixes #577 

Stop a couple of crashes when some expected entities aren't found, and give some useful warnings