### PR TITLE
Handle entities that might not have be correlated in resolving links

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -105,6 +105,10 @@ SUBLINK_TYPES = {
 
 def _find_in_list(collection: Iterable, name: str) -> Optional[FortranBase]:
     for item in collection:
+        # `item` might still be a string if we've not managed to
+        # correlate it for whatever reason, if so skip it
+        if not isinstance(item, FortranBase):
+            continue
         if name == item.name.lower():
             return item
     return None

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1256,3 +1256,35 @@ def test_find(copy_fortran_file):
     assert isinstance(prog_foo, FortranProgram)
     mod_foo = project.find("foo", entity="module")
     assert isinstance(mod_foo, FortranModule)
+
+
+def test_links_in_deferred_bound_methods(copy_fortran_file):
+    """Test for issue #591"""
+
+    data = """\
+    module test
+        type, abstract :: foo_t
+            contains
+            !> See [[foo_t]] for more information about [[foo]]
+            procedure(foo_iface), deferred :: foo
+        end type
+        abstract interface
+            subroutine foo_iface(self)
+                import :: foo_t
+                class(foo_t), intent(in) :: self
+            end subroutine
+        end interface
+    end module
+    """
+
+    settings = copy_fortran_file(data)
+    project = create_project(settings)
+    md = MetaMarkdown(settings.md_base_dir, project=project)
+    project.markdown(md, ".")
+
+    docstring = BeautifulSoup(
+        project.modules[0].types[0].boundprocs[0].doc, features="html.parser"
+    )
+    links = {link.text: link["href"] for link in docstring.find_all("a")}
+    assert links["foo_t"] == "./type/foo_t.html"
+    assert links["foo"] == "./type/foo_t.html#boundprocedure-foo"


### PR DESCRIPTION
This seems to happen with deferred bound procedures

Fixes #591