### PR TITLE
Ensure proper data types for command line arguments to fix #601

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -50,8 +50,12 @@ from ford._typing import PathLike
 from ford.pagetree import get_page_tree
 from ford._markdown import MetaMarkdown
 from ford.version import __version__
-from ford.settings import ProjectSettings, load_markdown_settings, load_toml_settings, \
-                          convert_types_from_commandarguments
+from ford.settings import (
+    ProjectSettings,
+    load_markdown_settings,
+    load_toml_settings,
+    convert_types_from_commandarguments,
+)
 
 
 __appname__ = "FORD"

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -50,7 +50,8 @@ from ford._typing import PathLike
 from ford.pagetree import get_page_tree
 from ford._markdown import MetaMarkdown
 from ford.version import __version__
-from ford.settings import ProjectSettings, load_markdown_settings, load_toml_settings
+from ford.settings import ProjectSettings, load_markdown_settings, load_toml_settings, \
+                          convert_types_from_commandarguments
 
 
 __appname__ = "FORD"
@@ -256,8 +257,8 @@ def get_command_line_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--externalize",
-        action="store_const",
-        const="true",
+        action="store_true",
+        default=None,
         help="provide information about Fortran objects in a json database for "
         "other FORD projects to refer to.",
     )
@@ -333,9 +334,7 @@ def parse_arguments(
             setattr(proj_data, key, value)
 
     # Get the default options, and any over-rides, straightened out
-    for key, value in command_line_args.items():
-        if value is not None:
-            setattr(proj_data, key, value)
+    proj_data = convert_types_from_commandarguments(proj_data, command_line_args)
 
     proj_data.normalise_paths(directory)
 

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -357,7 +357,7 @@ def convert_setting(default_type: Type, key: str, value: Any) -> Any:
             return {file_type.extension: file_type for file_type in file_types}
         else:
             sep = OPTION_SEPARATORS[key]
-            return _parse_to_dict(value, name=key, sep=sep)
+            return _parse_to_dict(resvalue, name=key, sep=sep)
 
     # Nothing special to do
     return value

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -327,6 +327,44 @@ def load_markdown_settings(
     return ProjectSettings.from_markdown_metadata(settings), "\n".join(project_lines)
 
 
+def convert_setting(default_type: Type, key: str, value: Any) -> Any:
+    """Convert an individual value's type to be consistent with a given dataclass for the
+       given key."""
+
+    if is_same_type(default_type, type(value)):
+        # already correct type
+        return value
+    if is_same_type(default_type, list):
+        return [value]
+    elif is_same_type(default_type, bool):
+        return convert_to_bool(key, value)
+    elif is_same_type(default_type, int):
+        return int(value[0])
+    elif (
+        is_same_type(default_type, str) or is_same_type(default_type, Path)
+    ) and isinstance(value, list):
+        return "\n".join(value)
+    elif (get_origin(default_type) == dict) and not isinstance(value, dict):
+        resvalue = value
+        if isinstance(value, str):
+            resvalue = [value]
+
+        # Get rid of any empty strings
+        resvalue = [v for v in resvalue if v]
+
+        if get_args(default_type) == (str, ExtraFileType):
+            file_types = [ExtraFileType.from_string(string) for string in resvalue]
+            return {
+                file_type.extension: file_type for file_type in file_types
+            }
+        else:
+            sep = OPTION_SEPARATORS[key]
+            return _parse_to_dict(value, name=key, sep=sep)
+
+    # Nothing special to do
+    return value
+
+
 def convert_types_from_metapreprocessor(
     cls: Type, settings: Dict[str, Any], parent: Optional[str] = None
 ):
@@ -345,36 +383,29 @@ def convert_types_from_metapreprocessor(
             keys_to_drop.append(key)
             continue
 
-        if is_same_type(default_type, type(value)):
-            continue
-        if is_same_type(default_type, list):
-            settings[key] = [value]
-        elif is_same_type(default_type, bool):
-            settings[key] = convert_to_bool(key, value)
-        elif is_same_type(default_type, int):
-            settings[key] = int(value[0])
-        elif (
-            is_same_type(default_type, str) or is_same_type(default_type, Path)
-        ) and isinstance(value, list):
-            settings[key] = "\n".join(value)
-        elif (get_origin(default_type) == dict) and not isinstance(value, dict):
-            if isinstance(value, str):
-                value = [value]
-
-            # Get rid of any empty strings
-            value = [v for v in value if v]
-
-            if get_args(default_type) == (str, ExtraFileType):
-                file_types = [ExtraFileType.from_string(string) for string in value]
-                settings[key] = {
-                    file_type.extension: file_type for file_type in file_types
-                }
-            else:
-                sep = OPTION_SEPARATORS[key]
-                settings[key] = _parse_to_dict(value, name=key, sep=sep)
+        settings[key] = convert_setting(default_type, key, value)
 
     for key in keys_to_drop:
         settings.pop(key)
+
+    return settings
+
+
+def convert_types_from_commandarguments(
+    settings: ProjectSettings, cargs: Dict[str, Any], parent: Optional[str] = None
+):
+    """Convert the cargs dict's value's types to be consistent with a given dataclass
+       if set and override them in settings.
+    """
+
+    field_types = get_type_hints(type(settings))
+
+    for key, value in cargs.items():
+        if value != None:
+            if key in field_types:
+                setattr(settings, key, convert_setting(field_types[key], key, value))
+            else:
+                setattr(settings, key, value)
 
     return settings
 

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -329,7 +329,7 @@ def load_markdown_settings(
 
 def convert_setting(default_type: Type, key: str, value: Any) -> Any:
     """Convert an individual value's type to be consistent with a given dataclass for the
-       given key."""
+    given key."""
 
     if is_same_type(default_type, type(value)):
         # already correct type
@@ -354,9 +354,7 @@ def convert_setting(default_type: Type, key: str, value: Any) -> Any:
 
         if get_args(default_type) == (str, ExtraFileType):
             file_types = [ExtraFileType.from_string(string) for string in resvalue]
-            return {
-                file_type.extension: file_type for file_type in file_types
-            }
+            return {file_type.extension: file_type for file_type in file_types}
         else:
             sep = OPTION_SEPARATORS[key]
             return _parse_to_dict(value, name=key, sep=sep)
@@ -395,7 +393,7 @@ def convert_types_from_commandarguments(
     settings: ProjectSettings, cargs: Dict[str, Any], parent: Optional[str] = None
 ):
     """Convert the cargs dict's value's types to be consistent with a given dataclass
-       if set and override them in settings.
+    if set and override them in settings.
     """
 
     field_types = get_type_hints(type(settings))

--- a/test/test_initialisation.py
+++ b/test/test_initialisation.py
@@ -240,3 +240,11 @@ def test_config_option():
     assert data.quiet is True
     assert data.display == ["public"]
     assert data.alias == {"a": "b", "c": "d"}
+
+
+def test_external_links_command_line_arg():
+    data, _ = ford.parse_arguments(
+        {"external": "remote = https://some.link"}, "", ford.ProjectSettings()
+    )
+
+    assert data.external == {"remote": "https://some.link"}


### PR DESCRIPTION
The command line arguments also have to conform with the `ProjectSettings` data types. With these changes they are also passed through the converter that is also used for the MD meta data. I am not quite sure if this is the proper way to go about it, but it resolves #601 for me.