### PR TITLE
Fix clash between table and alias syntax

### DIFF
--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -246,6 +246,22 @@ There are three predefined macros:
 You can defined additional custom aliases with the `alias
 <option-alias>` option.
 
+.. note::
+   Because the `markdown syntax for tables
+   <https://python-markdown.github.io/extensions/tables/>`_ also uses
+   pipes, you should ensure there is whitespace around the pipes for
+   tables and **no** whitespace in aliases:
+
+   .. code:: markdown
+
+       | Table Col 1 | Table Col 2 |
+       | ----------- | ----------- |
+       | note spaces | around pipes |
+       | [link](|page|/subpage2.html) | |note_no_space_in_alias| |
+
+   This avoids clashes between the syntax for the two features.
+
+
 .. _writing-links:
 
 Links

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -1,5 +1,7 @@
 from ford._markdown import MetaMarkdown
 
+from textwrap import dedent
+
 
 def test_sub_alias():
     result = MetaMarkdown(aliases={"a": "b"}).convert("|a|")
@@ -11,6 +13,25 @@ def test_sub_alias_with_equals():
     result = MetaMarkdown(aliases={"a": "b=c"}).convert("|a|")
 
     assert result == "<p>b=c</p>"
+
+
+def test_sub_alias_in_table():
+    text = dedent(
+        """
+        |Table Col 1| Table Col 2 |
+        |-----------| ----------- |
+        |normal| entry |
+        | [link](|page|/subpage2.html) | |other| |
+        """
+    )
+
+    result = MetaMarkdown(
+        aliases={"page": "/home/page", "other": "some alias"}
+    ).convert(text)
+
+    assert "[link]" not in result
+    assert 'href="/home/page/subpage2.html"' in result
+    assert "some alias" in result
 
 
 def test_fix_relative_paths(tmp_path):


### PR DESCRIPTION
Fixes #604

Turns out this was a bit more complicated than expected as tables are "block processors" and I had implemented aliases as "inline processors", which always run after block processors. So this required rewriting the processor as a "preprocessor" which always run before block processors.