### PR TITLE
Ensure all internal links are relative

### DIFF
--- a/example/pages/subdir/subsubpage.md
+++ b/example/pages/subdir/subsubpage.md
@@ -4,3 +4,6 @@ title: Subpage in subdirectory
 This page is deeper in the hierarchy. You can use `|page|` in URLs to
 link to other places in the page hierarchy, [such as this other
 subpage](|page|/subpage1.html)
+
+You can link to the API documentation with the Ford `[[link]]` style:
+[[ford_test_program]]

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -439,7 +439,7 @@ def main(proj_data: ProjectSettings, proj_docs: str):
     )
 
     # Convert the documentation from Markdown to HTML
-    proj_docs = md.reset().convert(proj_docs)
+    proj_docs = md.reset().convert(proj_docs, path=proj_data.project_url)
     project.markdown(md)
 
     # Convert summaries and descriptions to HTML

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -412,8 +412,6 @@ def main(proj_data: ProjectSettings, proj_docs: str):
         )
         sys.exit(1)
 
-    base_url = ".." if proj_data.relative else proj_data.project_url
-
     print("  Correlating information from different parts of your project...")
     correlate_time_start = time.time()
     project.correlate()
@@ -434,20 +432,17 @@ def main(proj_data: ProjectSettings, proj_docs: str):
 
     md = MetaMarkdown(
         proj_data.md_base_dir,
+        base_url=proj_data.project_url,
         extensions=proj_data.md_extensions,
         aliases=aliases,
         project=project,
-        relative=proj_data.relative,
-        base_url=proj_data.project_url,
     )
 
     # Convert the documentation from Markdown to HTML
     proj_docs = md.reset().convert(proj_docs)
-    project.markdown(md, base_url)
+    project.markdown(md)
 
     # Convert summaries and descriptions to HTML
-    if proj_data.relative:
-        ford.sourceform.set_base_url(".")
     if proj_data.summary is not None:
         proj_data.summary = md.convert(proj_data.summary)
     if proj_data.author_description is not None:

--- a/ford/external_project.py
+++ b/ford/external_project.py
@@ -61,7 +61,7 @@ def obj2dict(intObj):
         return None
     extDict = {
         "name": intObj.name,
-        "external_url": intObj.get_url(),
+        "external_url": f"./{intObj.get_url()}",
         "obj": intObj.obj,
     }
     if hasattr(intObj, "proctype"):

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -32,7 +32,6 @@ from fnmatch import fnmatch
 from ford.console import warn
 from ford.external_project import load_external_modules
 from ford.utils import ProgressBar
-import ford.sourceform
 from ford.sourceform import (
     _find_in_list,
     FortranBase,
@@ -340,11 +339,6 @@ class Project:
             if not isinstance(container, str):
                 container.prune()
 
-        if self.settings.project_url == ".":
-            url = ".."
-        else:
-            url = self.settings.project_url
-
         # Mapping of various entity containers in code units to the
         # corresponding container in the project
         CONTAINERS = {
@@ -386,11 +380,10 @@ class Project:
         self.prog_lines = sum_lines(self.programs)
         self.block_lines = sum_lines(self.blockdata)
 
-    def markdown(self, md, base_url=".."):
+    def markdown(self, md):
         """
         Process the documentation with Markdown to produce HTML.
         """
-        ford.sourceform.set_base_url(base_url)
         if self.settings.warn:
             print()
 

--- a/ford/output.py
+++ b/ford/output.py
@@ -31,8 +31,9 @@ from itertools import chain
 import pathlib
 import time
 from typing import List, Union, Callable, Type, Tuple
+from warnings import simplefilter
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
 import jinja2
 
 from ford.console import warn
@@ -49,6 +50,9 @@ env = jinja2.Environment(
     lstrip_blocks=True,
 )
 env.globals["path"] = os.path  # this lets us call path.* in templates
+
+# Ignore bs4 warning about parsing strings that look like filenames
+simplefilter("ignore", MarkupResemblesLocatorWarning)
 
 
 def is_more_than_one(collection):

--- a/ford/pagetree.py
+++ b/ford/pagetree.py
@@ -39,8 +39,6 @@ class PageNode:
     Object representing a page in a tree of pages and subpages.
     """
 
-    base_url = Path("..")
-
     def __init__(
         self,
         md: MetaMarkdown,
@@ -52,6 +50,7 @@ class PageNode:
     ):
         meta, text = meta_preprocessor(dedent(Path(path).read_text(encoding)))
         self.meta = EntitySettings.from_markdown_metadata(meta, path.stem)
+        self.base_url = Path(md.base_url)
 
         if self.meta.title is None:
             raise ValueError(f"Page '{path}' has no title metadata")
@@ -183,7 +182,3 @@ def get_page_tree(
             node.files.append(name)
 
     return node
-
-
-def set_base_url(url):
-    PageNode.base_url = Path(url)

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -426,7 +426,7 @@ class FortranBase:
         )
 
         if self.meta.summary is not None:
-            self.meta.summary = md.convert("\n".join(self.meta.summary))
+            self.meta.summary = md.convert("\n".join(self.meta.summary), context=self)
         elif paragraph := PARA_CAPTURE_RE.search(self.doc):
             # If there is no stand-alone webpage for this item, e.g.
             # an internal routine, make the whole doc blob appear,

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -432,7 +432,7 @@ class FortranBase:
             self.meta.summary = ""
 
         if self.meta.summary.strip() != self.doc.strip():
-            self.meta.summary += f'<a href="{self.full_url}" class="pull-right"><emph>Read more&hellip;</emph></a>'
+            self.meta.summary += f'<a href="../{self.get_url()}" class="pull-right"><emph>Read more&hellip;</emph></a>'
 
         if self.obj in ["proc", "type", "program"] and self.meta.source:
             obj = getattr(self, "proctype", self.obj).lower()

--- a/ford/templates/absint_list.html
+++ b/ford/templates/absint_list.html
@@ -13,7 +13,11 @@ All Abstract Interfaces &ndash; {{ project }}
 			 <tr><th>Abstract Interface</th><th>Location</th><th>Description</th></tr>
 			 </thead><tbody>
 			 {% for absint in project.absinterfaces|sort(attribute='name') %}
-			   <tr><td>{{ absint }}</td><td>{{ absint.parent }}</td><td>{{ absint.procedure | meta('summary') }}</td></tr>
+			   <tr>
+                 <td>{{ absint | relurl(page_url) }}</td>
+                 <td>{{ absint.parent | relurl(page_url) }}</td>
+                 <td>{{ absint.procedure | meta('summary') | relurl(page_url) }}</td>
+               </tr>
 			 {% endfor %}
 			 </tbody></table>
         </div>

--- a/ford/templates/absint_list.html
+++ b/ford/templates/absint_list.html
@@ -16,7 +16,7 @@ All Abstract Interfaces &ndash; {{ project }}
 			   <tr>
                  <td>{{ absint | relurl(page_url) }}</td>
                  <td>{{ absint.parent | relurl(page_url) }}</td>
-                 <td>{{ absint.procedure | meta('summary') | relurl(page_url) }}</td>
+                 <td>{{ absint.procedure | meta('summary') }}</td>
                </tr>
 			 {% endfor %}
 			 </tbody></table>

--- a/ford/templates/absint_list.html
+++ b/ford/templates/absint_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Abstract Interfaces &ndash; {{ project }}

--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -46,7 +46,7 @@
           <div id="navbar" class="navbar-collapse collapse">
             <ul class="navbar-nav">
               {% if pages %}
-                <li class="nav-item"><a class="nav-link" href="{{ pages.url }}">{{ pages.title }}</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ pages.url | relurl(page_url) }}">{{ pages.title }}</a></li>
               {% endif %}
               {% if incl_src %}
                 {% if (project.files|length + project.extra_files|length) is more_than_one %}

--- a/ford/templates/block_list.html
+++ b/ford/templates/block_list.html
@@ -12,7 +12,11 @@ All Block Data Units &ndash; {{ project }}
 			 <thead><tr><th>Block Data Unit</th><th>Source File</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for block in project.blockdata|sort(attribute='name') %}
-			   <tr><td>{{ block }}</td><td>{{ block.parent }}</td><td>{{ block | meta('summary') }}</td></tr>
+			   <tr>
+                 <td>{{ block | relurl(page_url) }}</td>
+                 <td>{{ block.parent | relurl(page_url) }}</td>
+                 <td>{{ block | meta('summary') | relurl(page_url) }}</td>
+               </tr>
 			 {% endfor %}
 			 </tbody></table>
         </div>

--- a/ford/templates/block_list.html
+++ b/ford/templates/block_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Block Data Units &ndash; {{ project }}

--- a/ford/templates/block_list.html
+++ b/ford/templates/block_list.html
@@ -15,7 +15,7 @@ All Block Data Units &ndash; {{ project }}
 			   <tr>
                  <td>{{ block | relurl(page_url) }}</td>
                  <td>{{ block.parent | relurl(page_url) }}</td>
-                 <td>{{ block | meta('summary') | relurl(page_url) }}</td>
+                 <td>{{ block | meta('summary') }}</td>
                </tr>
 			 {% endfor %}
 			 </tbody></table>

--- a/ford/templates/block_page.html
+++ b/ford/templates/block_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{{ blockdat.name|striptags }} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/file_list.html
+++ b/ford/templates/file_list.html
@@ -12,7 +12,10 @@ All Files &ndash; {{ project }}
 			 <thead><tr><th>File</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for src in project.allfiles|sort(attribute='name') %}
-			   <tr><td>{{ src }}</td><td>{{ src | meta('summary') }}</td></tr>
+			   <tr>
+                 <td>{{ src | relurl(page_url) }}</td>
+                 <td>{{ src | meta('summary') | relurl(page_url) }}</td>
+               </tr>
 			 {% endfor %}
 			 </tbody></table>
 			 {{ project.filegraph }}

--- a/ford/templates/file_list.html
+++ b/ford/templates/file_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Files &ndash; {{ project }}

--- a/ford/templates/file_list.html
+++ b/ford/templates/file_list.html
@@ -14,7 +14,7 @@ All Files &ndash; {{ project }}
 			 {% for src in project.allfiles|sort(attribute='name') %}
 			   <tr>
                  <td>{{ src | relurl(page_url) }}</td>
-                 <td>{{ src | meta('summary') | relurl(page_url) }}</td>
+                 <td>{{ src | meta('summary') }}</td>
                </tr>
 			 {% endfor %}
 			 </tbody></table>

--- a/ford/templates/file_page.html
+++ b/ford/templates/file_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}s
 {% block title %}{{ src.name }} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/genint_page.html
+++ b/ford/templates/genint_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{{ interface.name }} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -94,7 +94,7 @@
               <h3>Source Files</h3>
               <ul>
                 {%- for src in (project.allfiles|sort(attribute='name'))[:max_length] -%}
-                  <li>{{ src }}</li>
+                  <li>{{ src | relurl(page_url) }}</li>
                 {%- endfor -%}
               </ul>
             </div>
@@ -111,7 +111,7 @@
               <h3>Modules</h3>
               <ul>
                 {%- for mod in (project.modules|sort(attribute='name'))[:max_length] -%}
-                  <li>{{ mod }}</li>
+                  <li>{{ mod | relurl(page_url) }}</li>
                 {%- endfor -%}
               </ul>
             </div>
@@ -128,7 +128,7 @@
               <h3>Procedures</h3>
               <ul>
                 {%- for proc in (project.procedures|sort(attribute='name'))[:max_length] -%}
-                  <li>{{ proc }}</li>
+                  <li>{{ proc | relurl(page_url) }}</li>
                 {%- endfor -%}
               </ul>
             </div>
@@ -145,7 +145,7 @@
               <h3>Derived Types</h3>
               <ul>
                 {%- for dtype in (project.types|sort(attribute='name'))[:max_length] -%}
-                  <li>{{ dtype }}</li>
+                  <li>{{ dtype | relurl(page_url) }}</li>
                 {%- endfor -%}
               </ul>
             </div>

--- a/ford/templates/info_page.html
+++ b/ford/templates/info_page.html
@@ -21,7 +21,7 @@
           <nav aria-label="breadcrumb">
             <ol class="breadcrumb justify-content-end mb-0">
               {% for item in page.hierarchy %}
-                <li class="breadcrumb-item">{{ item }}</li>
+                <li class="breadcrumb-item">{{ item | relurl(page_url) }}</li>
               {% endfor %}
               <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
             </ol>

--- a/ford/templates/info_page.html
+++ b/ford/templates/info_page.html
@@ -37,13 +37,13 @@
         <div class="card card-body bg-light" id="sidebar-toc">
           <ul class="nav flex-column align-items">
             <li class="nav-item">
-              <a class="nav-link{% if pages==page %} active disabled{% endif %}" href="{{ pages.url}}">{{ pages.title }}</a>
+              <a class="nav-link{% if pages==page %} active disabled{% endif %}" href="{{ pages.url | relurl(page_url) }}">{{ pages.title }}</a>
             </li>
           </ul>
           <hr>
           <nav class="nav nav-pills flex-column">
             {% for subpage in pages.subpages recursive %}
-              <a class="nav-link{% if subpage==page %} active disabled{% endif %}" href="{{ subpage.url}}">{{ subpage.title }}</a>
+              <a class="nav-link{% if subpage==page %} active disabled{% endif %}" href="{{ subpage.url | relurl(page_url) }}">{{ subpage.title }}</a>
               {% if subpage.subpages %}
                 <nav class="nav nav-pills flex-column">
                   {{ loop(subpage.subpages) }}

--- a/ford/templates/info_page.html
+++ b/ford/templates/info_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{{ page.title }} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% macro info_bar(entity, incl_src, base_url, line_info) %}
   <div class="container p-2 mb-4 bg-light border rounded-3">
     <div class="row align-items-center justify-content-between" id="info-bar">

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -85,7 +85,7 @@
               {% set name = item.name if item.name else "<em>unnamed</em>" %}
               {% set anchor = item.anchor %}
             {% endif %}
-            {% set anchor_url = "{}#{}".format(collection_url, anchor) if collection_url else item.get_url() %}
+            {% set anchor_url = "../{}#{}".format(collection_url, anchor) if collection_url else "../{}".format(item.get_url()) %}
             <a class="list-group-item" href="{{ anchor_url }}">{{ name }}</a>
           {% endfor %}
         </div>
@@ -121,7 +121,7 @@
     <div class="card card-primary">
       <div class="card-header text-left"><h3 class="card-title">Source Code</h3></div>
       <div class="list-group">
-        <a class="list-group-item" href="{{ self.get_url() }}#src">{{ self.name }}</a>
+        <a class="list-group-item" href="../{{ self.get_url() }}#src">{{ self.name }}</a>
       </div>
     </div>
   {% endif %}
@@ -223,7 +223,7 @@
             {% endif %}
             <td>
               {% if summary -%}
-                {{ var | meta('summary') }}
+                {{ var | meta('summary') | relurl(page_url) }}
               {% else %}
                 {{ var.doc }}
               {% endif %}
@@ -374,7 +374,7 @@
                 {% if not bind.visible %}
                   {{ meta_list(bind.meta) }}
                 {% endif %}
-                {{ bind | meta('summary') }}
+                {{ bind | meta('summary') | relurl(page_url) }}
               {% endif %}
               {{ binding_summary(bind.procedure) }}
             {% else %}
@@ -441,7 +441,7 @@
     {% if intr.doc or meta_list(intr.meta)|trim %}
       <div class="card-body">
         {{ meta_list(intr.meta) }}
-        {{ intr | meta('summary') }}
+        {{ intr | meta('summary') | relurl(page_url) }}
       </div>
     {% endif %}
     <ul class="list-group">
@@ -453,10 +453,10 @@
 {% endmacro %}
 
 {% macro proc_line(proc, link=True, proto=False) %}
-  {% if proc.mp %}module procedure {% if not proc.parent or (proc.visible and link) %}{{ proc }}{% else %}{{ proc.name }}{% endif %} <small>{% endif -%}
+  {% if proc.mp %}module procedure {% if not proc.parent or (proc.visible and link) %}{{ page_url }} {{ proc | relurl(page_url) }}{% else %}{{ proc.name }}{% endif %} <small>{% endif -%}
   {% if (proc.parobj == 'module' or (proc.parobj == 'interface' and proc.parent.parobj == 'module')) and not proto %}{{ proc.permission }} {% endif -%}
   {{ proc.attribs | join(" ") }} {{ proc.proctype |lower }}
-  {%- if not proc.parent or (proc.visible and link and not proc.mp) %} {{ proc }}{% else %} {{ proc.name }}{% endif -%}
+  {%- if not proc.parent or (proc.visible and link and not proc.mp) %} {{ proc | relurl(page_url) }}{% else %} {{ proc.name }}{% endif -%}
   ({{ proc.args | join(", ") }})
   {%- if proc.proctype|lower == 'function' and proc.name != proc.retvar.name %} result({{ proc.retvar.name }}){% endif -%}
   {% if proc.bindC %} bind({{ proc.bindC }}){% endif %}
@@ -464,7 +464,7 @@
   {{ deprecated(proc) }}
   {% if proc.module and proc.module != True and proc.module.visible %}
     {% set label = "Implementation" if proc.parobj == 'interface' else "Interface" %}
-    <a href='{{ proc.module.get_url() }}'><button type="button" class="btn btn-info depwarn">{{ label }} &rarr;</button></a>
+    <a href="../{{ proc.module.get_url() }}"><button type="button" class="btn btn-info depwarn">{{ label }} &rarr;</button></a>
   {% endif %}
 {% endmacro %}
 
@@ -502,7 +502,7 @@
         {%- if dtype.parobj == 'module' %}, {{ dtype.permission }}{% endif -%}
         {%- if dtype.sequence %}, sequence {% endif -%}
         {{ dtype.attribs | join(", ") }}
-        {%- if dtype.extends %}, extends({{ dtype.extends }}){% endif -%}&nbsp;::&nbsp;
+        {%- if dtype.extends %}, extends({{ dtype.extends | relurl(page_url) }}){% endif -%}&nbsp;::&nbsp;
         {{ dtype }}
         {{ deprecated(dtype) }}
       </h3>
@@ -511,7 +511,7 @@
       {% if not dtype.visible %}
         {{ meta_list(dtype.meta) }}
       {% endif %}
-      {{ dtype | meta('summary') }}
+      {{ dtype | meta('summary') | relurl(page_url) }}
 
       {% if dtype.variables %}
         <h4>Components</h4>
@@ -556,7 +556,7 @@
             {% for fin in dtype.finalprocs %}
               <tr>
                 <td>final :: <strong>{{ fin.name }}</strong></td>
-                <td>{{ fin | meta('summary') }}</td>
+                <td>{{ fin | meta('summary') | relurl(page_url) }}</td>
               </tr>
             {% endfor %}
           </tbody>
@@ -570,7 +570,7 @@
             {% for tb in dtype.boundprocs %}
               <tr>
                 <td>{{ bound_declaration(tb, link_name=True) }}</td>
-                <td>{{ tb | meta('summary') }}</td>
+                <td>{{ tb | meta('summary') | relurl(page_url) }}</td>
               </tr>
               {% endfor %}
           </tbody>
@@ -611,7 +611,7 @@
 {% macro common_popover(common) %}
   {%- for item in common.other_uses -%}
     {%- if item != common -%}
-      <a href='{{ item.get_url() }}'>{% if item.parent.name -%}{{ item.parent.name }}{%- else -%}<em>unnamed</em>{%- endif %}</a>
+      <a href="../{{ item.get_url() }}">{% if item.parent.name -%}{{ item.parent.name }}{%- else -%}<em>unnamed</em>{%- endif %}</a>
       ({% if item.parobj == 'proc' -%}{{ item.parent.proctype|lower }}{%- else -%}{{ item.parobj }}{%- endif %})<br>
     {%- endif -%}
   {%- endfor -%}
@@ -627,7 +627,7 @@
           {% for var in enum.variables %}
             <tr>
               <td>{{ var.vartype }}</td><td>::</td>
-              <td><strong>{{ var.name }}</strong></td><td> = </td><td>{{ var.initial }}</td><td>{% if summary -%}{{ var | meta('summary') }}{% else %}{{ var.doc }}{% endif %}</td>
+              <td><strong>{{ var.name }}</strong></td><td> = </td><td>{{ var.initial }}</td><td>{% if summary -%}{{ var | meta('summary') | relurl(page_url) }}{% else %}{{ var.doc }}{% endif %}</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -643,7 +643,7 @@
 
 {% macro proc_entry(proc) %}
   <div class="card">
-    <div class="card-header codesum"><span class="anchor" id="{{ proc.anchor }}"></span><h3>{{ proc_line(proc) }}</h3></div>
+    <div class="card-header codesum"><span class="anchor" id="{{ proc.anchor }}"></span>{{ honkle }} <h3>{{ proc_line(proc) }}</h3></div>
     <div class="card-body">
       {{ proc_summary(proc,False) }}
     </div>

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -47,11 +47,11 @@
           <ol class="breadcrumb justify-content-end mb-0">
             {% if incl_src %}
               {% for item in entity.hierarchy %}
-                <li class="breadcrumb-item">{{ item }}</li>
+                <li class="breadcrumb-item">{{ item | relurl(page_url) }}</li>
               {% endfor %}
             {% else %}
               {% for item in entity.hierarchy[1:] %}
-                <li class="breadcrumb-item">{{ item }}</li>
+                <li class="breadcrumb-item">{{ item | relurl(page_url) }}</li>
               {% endfor %}
             {%endif%}
             <li class="breadcrumb-item active" aria-current="page">{{ entity.name }}</li>
@@ -193,7 +193,7 @@
           {% if var.obj == 'variable' %}
             <td>
               <span class="anchor" {% if id %}id="{{ var.anchor }}"{% endif %}></span>
-              {{ var.full_type }}{{ add_comma((intent and var.intent) or var.optional or permission or var.parameter or var.attribs) }}
+              {{ var.full_type | relurl(page_url) }}{{ add_comma((intent and var.intent) or var.optional or permission or var.parameter or var.attribs) }}
             </td>
             {% if intent -%}
               <td>
@@ -286,7 +286,7 @@
   {% if proc.retvar %}
     {{ header(4, small) }}
     Return Value
-    <small>{{ proc.retvar.full_declaration }}</small>
+    <small>{{ proc.retvar.full_declaration | relurl(page_url) }}</small>
     {{ close_header(4, small) }}
     {{ docstring(proc.retvar, full_docstring) }}
   {% endif %}
@@ -317,7 +317,7 @@
   {% if proc.retvar %}
     {{ header(4, small) }}
     Return Value
-    <small>{{ proc.retvar.full_declaration }}</small>
+    <small>{{ proc.retvar.full_declaration | relurl(page_url) }}</small>
     {{ close_header(4, small) }}
     {{ proc.retvar.doc }}
   {% endif %}
@@ -326,8 +326,8 @@
 
 {% macro bound_declaration(tb, link_name=False) %}
   {# Type-bound procedure declaration and bindings #}
-  {{ tb.full_declaration }} ::
-  <strong>{% if link_name %}{{ tb }}{% else %}{{ tb.name }}{% endif %}</strong>
+  {{ tb.full_declaration | relurl(page_url) }} ::
+  <strong>{% if link_name %}{{ tb | relurl(page_url) }}{% else %}{{ tb.name }}{% endif %}</strong>
   {%- if tb.generic or (tb.name != tb.bindings[0].name and tb.name != tb.bindings[0]) %} => {{ tb.bindings | join(", ") }}{% endif %}
   {% if tb.binding|length == 1 %}<small>{{ tb.bindings[0].proctype }}</small>{% endif %}
 {% endmacro %}
@@ -394,7 +394,7 @@
       <span class="anchor" id="{{ intr.anchor }}"></span>
       <h3>{% if intr.parobj == 'module' and intr.generic %}{{ intr.permission }}{% endif %}
         interface
-        {%- if intr.generic %} {{ intr }} {% endif -%}
+        {%- if intr.generic %} {{ intr | relurl(page_url) }} {% endif -%}
         {{ deprecated(intr) }}
       </h3>
     </div>
@@ -503,7 +503,7 @@
         {%- if dtype.sequence %}, sequence {% endif -%}
         {{ dtype.attribs | join(", ") }}
         {%- if dtype.extends %}, extends({{ dtype.extends | relurl(page_url) }}){% endif -%}&nbsp;::&nbsp;
-        {{ dtype }}
+        {{ dtype | relurl(page_url) }}
         {{ deprecated(dtype) }}
       </h3>
     </div>
@@ -570,7 +570,7 @@
             {% for tb in dtype.boundprocs %}
               <tr>
                 <td>{{ bound_declaration(tb, link_name=True) }}</td>
-                <td>{{ tb | meta('summary') }}</td>
+                <td>{{ tb | meta('summary') | relurl(page_url) }}</td>
               </tr>
               {% endfor %}
           </tbody>
@@ -655,7 +655,7 @@
   <div class="card">
     <div class="card-header codesum">
       <span class="anchor" id="{{ namelist.anchor }}"></span>
-      <h3>Namelist {{ namelist }}</h3>
+      <h3>Namelist {{ namelist | relurl(page_url) }}</h3>
     </div>
     <div class="card-body">
       {{ namelist_summary(namelist, False) }}
@@ -697,7 +697,7 @@
   {% else %}
     <tr id="{{ variable.anchor }}">
       <td><a href="#{{ variable.anchor }}">{{ variable.name }}</a></td>
-      <td>{{ variable.full_type }}</td>
+      <td>{{ variable.full_type | relurl(page_url) }}</td>
       <td>{{ variable.initial | e }}</td>
       <td>{{ docstring(variable, full_docstring) }}</td>
     </tr>
@@ -714,7 +714,7 @@
             <li class="list-group-item">
               <ul class="list-inline">
                 {% for use in obj.uses %}
-                  <li class="list-inline-item">{{ use }}</li>
+                  <li class="list-inline-item">{{ use | relurl(page_url) }}</li>
                 {% endfor %}
               </ul>
             </li>
@@ -723,8 +723,8 @@
             <li class="list-group-item">
               <ul class="list-inline">
                 <li><h5>Ancestors:</h5></li>
-                {% for anc in obj.ancestry %}
-                  <li class="list-inline-item">{{ anc }}</li>
+                {% for ancestor in obj.ancestry %}
+                  <li class="list-inline-item">{{ ancestor | relurl(page_url) }}</li>
                   {% if not loop.last -%}<li>:</li>{%- endif %}
                   {% endfor %}
               </ul>
@@ -752,8 +752,8 @@
             <li class="list-group-item">
               <ul class="list-inline">
                 <li class="list-inline-item"><h5>Descendants:</h5></li>
-                {% for anc in obj.descendants %}
-                  <li class="list-inline-item">{{ anc }}</li>
+                {% for ancestor in obj.descendants %}
+                  <li class="list-inline-item">{{ ancestor | relurl(page_url) }}</li>
                 {% endfor %}
               </ul>
             </li>

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -223,7 +223,7 @@
             {% endif %}
             <td>
               {% if summary -%}
-                {{ var | meta('summary') | relurl(page_url) }}
+                {{ var | meta('summary') }}
               {% else %}
                 {{ var.doc }}
               {% endif %}
@@ -374,7 +374,7 @@
                 {% if not bind.visible %}
                   {{ meta_list(bind.meta) }}
                 {% endif %}
-                {{ bind | meta('summary') | relurl(page_url) }}
+                {{ bind | meta('summary') }}
               {% endif %}
               {{ binding_summary(bind.procedure) }}
             {% else %}
@@ -441,7 +441,7 @@
     {% if intr.doc or meta_list(intr.meta)|trim %}
       <div class="card-body">
         {{ meta_list(intr.meta) }}
-        {{ intr | meta('summary') | relurl(page_url) }}
+        {{ intr | meta('summary') }}
       </div>
     {% endif %}
     <ul class="list-group">
@@ -511,7 +511,7 @@
       {% if not dtype.visible %}
         {{ meta_list(dtype.meta) }}
       {% endif %}
-      {{ dtype | meta('summary') | relurl(page_url) }}
+      {{ dtype | meta('summary') }}
 
       {% if dtype.variables %}
         <h4>Components</h4>
@@ -556,7 +556,7 @@
             {% for fin in dtype.finalprocs %}
               <tr>
                 <td>final :: <strong>{{ fin.name }}</strong></td>
-                <td>{{ fin | meta('summary') | relurl(page_url) }}</td>
+                <td>{{ fin | meta('summary') }}</td>
               </tr>
             {% endfor %}
           </tbody>
@@ -570,7 +570,7 @@
             {% for tb in dtype.boundprocs %}
               <tr>
                 <td>{{ bound_declaration(tb, link_name=True) }}</td>
-                <td>{{ tb | meta('summary') | relurl(page_url) }}</td>
+                <td>{{ tb | meta('summary') }}</td>
               </tr>
               {% endfor %}
           </tbody>
@@ -627,7 +627,7 @@
           {% for var in enum.variables %}
             <tr>
               <td>{{ var.vartype }}</td><td>::</td>
-              <td><strong>{{ var.name }}</strong></td><td> = </td><td>{{ var.initial }}</td><td>{% if summary -%}{{ var | meta('summary') | relurl(page_url) }}{% else %}{{ var.doc }}{% endif %}</td>
+              <td><strong>{{ var.name }}</strong></td><td> = </td><td>{{ var.initial }}</td><td>{% if summary -%}{{ var | meta('summary') }}{% else %}{{ var.doc }}{% endif %}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/ford/templates/mod_list.html
+++ b/ford/templates/mod_list.html
@@ -22,7 +22,7 @@ All Modules &ndash; {{ project }}
 			   <tr class="{% if loop.depth == 1 %}{{ row_class.current }}{% else %}{{ row_class.current }} submod{% endif %}">
                  <td>{% for i in range(loop.depth0) -%}&nbsp;&nbsp;&nbsp;{%- endfor %}{{ mod | relurl(page_url) }}</td>
                  <td>{{ mod.parent | relurl(page_url) }}</td>
-                 <td>{{ mod | meta("summary") | relurl(page_url) }}</td>
+                 <td>{{ mod | meta("summary") }}</td>
                </tr>
                {% if mod.descendants %}
                   {{ loop(mod.descendants) }}

--- a/ford/templates/mod_list.html
+++ b/ford/templates/mod_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Modules &ndash; {{ project }}

--- a/ford/templates/mod_list.html
+++ b/ford/templates/mod_list.html
@@ -19,7 +19,11 @@ All Modules &ndash; {{ project }}
 			 <tbody>
              {% set row_class = cycler('active', '') %}
 			 {% for mod in project.modules|sort(attribute='name') recursive %}
-			   <tr class="{% if loop.depth == 1 %}{{ row_class.current }}{% else %}{{ row_class.current }} submod{% endif %}"><td>{% for i in range(loop.depth0) -%}&nbsp;&nbsp;&nbsp;{%- endfor %}{{ mod }}</td><td>{{ mod.parent }}</td><td>{{ mod.meta.summary }}</td></tr>
+			   <tr class="{% if loop.depth == 1 %}{{ row_class.current }}{% else %}{{ row_class.current }} submod{% endif %}">
+                 <td>{% for i in range(loop.depth0) -%}&nbsp;&nbsp;&nbsp;{%- endfor %}{{ mod | relurl(page_url) }}</td>
+                 <td>{{ mod.parent | relurl(page_url) }}</td>
+                 <td>{{ mod | meta("summary") | relurl(page_url) }}</td>
+               </tr>
                {% if mod.descendants %}
                   {{ loop(mod.descendants) }}
                {% endif %}

--- a/ford/templates/mod_page.html
+++ b/ford/templates/mod_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{{ module.name }} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/namelist_list.html
+++ b/ford/templates/namelist_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 
 {% block title %}

--- a/ford/templates/namelist_list.html
+++ b/ford/templates/namelist_list.html
@@ -17,7 +17,7 @@ All namelists &ndash; {{ project }}
             <tr>
               <td>{{ namelist | relurl(page_url) }}</td>
               <td>{{ namelist.parent | relurl(page_url) }}</td>
-              <td>{{ namelist | meta('summary') | relurl(page_url) }}</td>
+              <td>{{ namelist | meta('summary') }}</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/ford/templates/namelist_list.html
+++ b/ford/templates/namelist_list.html
@@ -14,7 +14,11 @@ All namelists &ndash; {{ project }}
         <thead><tr><th>Namelist</th><th>Location</th><th>Description</th></tr></thead>
         <tbody>
           {% for namelist in project.namelists | sort(attribute="name") %}
-            <tr><td>{{ namelist }}</td><td>{{ namelist.parent }}</td><td>{{ namelist | meta('summary') }}</td></tr>
+            <tr>
+              <td>{{ namelist | relurl(page_url) }}</td>
+              <td>{{ namelist.parent | relurl(page_url) }}</td>
+              <td>{{ namelist | meta('summary') | relurl(page_url) }}</td>
+            </tr>
           {% endfor %}
         </tbody>
       </table>

--- a/ford/templates/namelist_page.html
+++ b/ford/templates/namelist_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 
 {% block title %}

--- a/ford/templates/nongenint_page.html
+++ b/ford/templates/nongenint_page.html
@@ -1,3 +1,4 @@
+<!-- -*- mode: jinja2 -*- -->
 
 {% extends "base.html" %}
 {% block title %}{{ interface.name }} &ndash; {{ project }}{% endblock title %}

--- a/ford/templates/proc_list.html
+++ b/ford/templates/proc_list.html
@@ -12,7 +12,12 @@ All Procedures &ndash; {{ project }}
 			 <thead><tr><th>Procedure</th><th>Location</th><th>Procedure Type</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for proc in project.procedures|sort(attribute='name') %}
-			   <tr><td>{{ proc }}</td><td>{{ proc.parent }}</td><td>{{ proc.proctype }}</td><td>{{ proc | meta('summary') }}</td></tr>
+			   <tr>
+                 <td>{{ proc | relurl(page_url) }}</td>
+                 <td>{{ proc.parent | relurl(page_url) }}</td>
+                 <td>{{ proc.proctype }}</td>
+                 <td>{{ proc | meta('summary') | relurl(page_url) }}</td>
+               </tr>
 			 {% endfor %}
 			 </tbody></table>
              {{ project.callgraph }}

--- a/ford/templates/proc_list.html
+++ b/ford/templates/proc_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Procedures &ndash; {{ project }}

--- a/ford/templates/proc_list.html
+++ b/ford/templates/proc_list.html
@@ -16,7 +16,7 @@ All Procedures &ndash; {{ project }}
                  <td>{{ proc | relurl(page_url) }}</td>
                  <td>{{ proc.parent | relurl(page_url) }}</td>
                  <td>{{ proc.proctype }}</td>
-                 <td>{{ proc | meta('summary') | relurl(page_url) }}</td>
+                 <td>{{ proc | meta('summary') }}</td>
                </tr>
 			 {% endfor %}
 			 </tbody></table>

--- a/ford/templates/proc_page.html
+++ b/ford/templates/proc_page.html
@@ -28,7 +28,7 @@
 
     {% if procedure.binding %}
     <h3>Type Bound</h3>
-    <p>{{ procedure.binding.parent }}</p>
+    <p>{{ procedure.binding.parent | relurl(page_url) }}</p>
     {% endif %}
 
     <h3>Arguments</h3>
@@ -42,7 +42,7 @@
       <h3>Return Value
         <small>
           <span class="anchor" id="{{ procedure.retvar.anchor }}"></span>
-          {{ procedure.retvar.full_declaration }}
+          {{ procedure.retvar.full_declaration | relurl(page_url) }}
         </small>
       </h3>
       {{ procedure.retvar.doc }}

--- a/ford/templates/proc_page.html
+++ b/ford/templates/proc_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{{ procedure.name }} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/prog_list.html
+++ b/ford/templates/prog_list.html
@@ -12,7 +12,11 @@ All Programs &ndash; {{ project }}
 			 <thead><tr><th>Program</th><th>Source File</th><th>Description</th></tr></thead>
 			 <tbody>
 			 {% for prog in project.programs|sort(attribute='name') %}
-			   <tr><td>{{ prog }}</td><td>{{ prog.parent }}</td><td>{{ prog | meta('summary') }}</td></tr>
+			   <tr>
+                 <td>{{ prog | relurl(page_url) }}</td>
+                 <td>{{ prog.parent | relurl(page_url) }}</td>
+                 <td>{{ prog | meta('summary') | relurl(page_url) }}</td>
+               </tr>
 			 {% endfor %}
 			 </tbody></table>
         </div>

--- a/ford/templates/prog_list.html
+++ b/ford/templates/prog_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Programs &ndash; {{ project }}

--- a/ford/templates/prog_list.html
+++ b/ford/templates/prog_list.html
@@ -15,7 +15,7 @@ All Programs &ndash; {{ project }}
 			   <tr>
                  <td>{{ prog | relurl(page_url) }}</td>
                  <td>{{ prog.parent | relurl(page_url) }}</td>
-                 <td>{{ prog | meta('summary') | relurl(page_url) }}</td>
+                 <td>{{ prog | meta('summary') }}</td>
                </tr>
 			 {% endfor %}
 			 </tbody></table>

--- a/ford/templates/prog_page.html
+++ b/ford/templates/prog_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{% if program.name %}{{ program.name }}{% else %}unnamed{% endif %} &ndash; {{ project }}{% endblock title %}
 {% block body %}

--- a/ford/templates/type_page.html
+++ b/ford/templates/type_page.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}{{ dtype.name }} &ndash; {{ project }} {% endblock title %}
 {% block body %}

--- a/ford/templates/type_page.html
+++ b/ford/templates/type_page.html
@@ -18,28 +18,34 @@
     </div>
     
     <div class="col-md-9" id='text'>
-      <h2>type{% if dtype.parobj == 'module' %}, {{ dtype.permission }}{% endif %}{% for attr in dtype.attributes%}, {{ attr }}{% endfor %}{% if dtype.extends %}, extends({{ dtype.extends }}){% endif %} :: {{ dtype.name }}{% if dtype.sequence%}<br>sequence{% endif %}</h2>
+      <h2>
+        type
+        {%- if dtype.parobj == 'module' %}, {{ dtype.permission }}{% endif -%}
+        {{ dtype.attribs | join(", ") }}
+        {%- if dtype.extends %}, extends({{ dtype.extends | relurl(page_url) }}){% endif %} :: {{ dtype.name }}
+        {%- if dtype.sequence%}<br>sequence{% endif -%}
+      </h2>
     {{ dtype.doc }}
     {% if dtype.inherbygraph or dtype.inhergraph %}<br>{% endif %}
     {% if dtype.inhergraph %}
-    <div class="card">
-      <div class="card-header">
-  <h3 class="card-title">Inherits</h3>
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Inherits</h3>
+        </div>
+        <div class="card-body">
+          {{ dtype.inhergraph }}
+        </div>
       </div>
-      <div class="card-body">
-    {{ dtype.inhergraph }}
-      </div>
-    </div>
     {% endif %}
     {% if dtype.inherbygraph %}
-    <div class="card">
-      <div class="card-header">
-  <h3 class="card-title">Inherited by</h3>
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">Inherited by</h3>
+        </div>
+        <div class="card-body">
+          {{ dtype.inherbygraph }}
+        </div>
       </div>
-      <div class="card-body">
-     {{ dtype.inherbygraph }}
-      </div>
-    </div>
     {% endif %}
     <br>
 

--- a/ford/templates/types_list.html
+++ b/ford/templates/types_list.html
@@ -1,3 +1,5 @@
+<!-- -*- mode: jinja2 -*- -->
+
 {% extends "base.html" %}
 {% block title %}
 All Types &ndash; {{ project }}

--- a/ford/templates/types_list.html
+++ b/ford/templates/types_list.html
@@ -17,7 +17,7 @@ All Types &ndash; {{ project }}
                  <td>{{ dtype | relurl(page_url) }}</td>
                  <td>{{ dtype.parent | relurl(page_url) }}</td>
                  <td>{{ dtype.extends | relurl(page_url) }}</td>
-                 <td>{{ dtype | meta("summary") | relurl(page_url) }}</td>
+                 <td>{{ dtype | meta("summary") }}</td>
                </tr>
 			 {% endfor %}
 			 </tbody></table>

--- a/ford/templates/types_list.html
+++ b/ford/templates/types_list.html
@@ -13,7 +13,12 @@ All Types &ndash; {{ project }}
 			 <tr><th>Type</th><th>Location</th><th>Extends</th><th>Description</th></tr>
 			 </thead><tbody>
 			 {% for dtype in project.types|sort(attribute='name') %}
-			   <tr><td>{{ dtype }}</td><td>{{ dtype.parent }}</td><td>{{ dtype.extends }}</td><td>{{ dtype.meta.summary }}</td></tr>
+			   <tr>
+                 <td>{{ dtype | relurl(page_url) }}</td>
+                 <td>{{ dtype.parent | relurl(page_url) }}</td>
+                 <td>{{ dtype.extends | relurl(page_url) }}</td>
+                 <td>{{ dtype | meta("summary") | relurl(page_url) }}</td>
+               </tr>
 			 {% endfor %}
 			 </tbody></table>
              {{ project.typegraph }}

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -12,6 +12,8 @@ from bs4 import BeautifulSoup
 import pytest
 
 
+pytestmark = pytest.mark.filterwarnings("ignore::bs4.MarkupResemblesLocatorWarning")
+
 HEADINGS = re.compile(r"h[1-4]")
 ANY_TEXT = re.compile(r"h[1-4]|p")
 

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -366,7 +366,7 @@ def test_public_procedure_links(example_project):
 
 
 def test_all_internal_links_resolve(example_project):
-    """Opens every HTML file, finds all relative links and checks that
+    """Opens every HTML file, finds all internal links and checks that
     they resolve to files that actually exist. Furthermore, if the
     link has a fragment ("#something"), check that that fragment
     exists in the specified file.
@@ -383,11 +383,11 @@ def test_all_internal_links_resolve(example_project):
     for html, index in html_files.items():
         for a_tag in index("a"):
             link = urlparse(a_tag.get("href", ""))
-            if not link.path.startswith("."):
+            if link.netloc or link.scheme == "mailto" or not link.path:
                 continue
 
             link_path = (html.parent / link.path).resolve()
-            assert link_path.exists(), html
+            assert link_path.exists(), f"{a_tag} on page {html}"
 
             if not link.fragment:
                 continue
@@ -474,7 +474,7 @@ def test_static_pages(example_project):
 
     subpage_paths = [pathlib.Path(link["href"]) for link in subpage_links]
     expected_subpage_paths = [
-        pathlib.Path(f"../page/{link}.html")
+        pathlib.Path(f"{link}.html")
         for link in (
             "index",
             "subpage2",

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -386,6 +386,10 @@ def test_all_internal_links_resolve(example_project):
             if link.netloc or link.scheme == "mailto" or not link.path:
                 continue
 
+            assert not link.path.startswith(
+                "/"
+            ), f"absolute path in {a_tag} on page {html}"
+
             link_path = (html.parent / link.path).resolve()
             assert link_path.exists(), f"{a_tag} on page {html}"
 

--- a/test/test_graphs.py
+++ b/test/test_graphs.py
@@ -15,7 +15,7 @@ from bs4 import BeautifulSoup
 def create_project(settings: ProjectSettings):
     project = Project(settings)
     md = MetaMarkdown(project=project)
-    project.markdown(md, "..")
+    project.markdown(md)
     project.correlate()
     return project
 

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -15,7 +15,7 @@ def test_sub_alias_with_equals():
 
 def test_fix_relative_paths(tmp_path):
     base_path = tmp_path / "output"
-    md = MetaMarkdown(relative=True, base_url=tmp_path / "output")
+    md = MetaMarkdown(base_url=tmp_path / "output")
 
     text = f"[link to thing]({base_path / 'thing'})"
     result = md.convert(text, path=base_path / "other")

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -12,6 +12,8 @@ from ford._markdown import MetaMarkdown
 import ford.sourceform
 
 from itertools import chain
+from os.path import relpath
+import pathlib
 
 import pytest
 from bs4 import BeautifulSoup
@@ -1098,8 +1100,12 @@ def test_make_links(copy_fortran_file):
     ):
         docstring = BeautifulSoup(item.doc, features="html.parser")
         link_locations = {a.string: a.get("href", None) for a in docstring("a")}
+        base_dir = pathlib.Path(item.get_url()).parent
+        expected_links_rel = {
+            k: relpath(v, base_dir) for k, v in expected_links.items()
+        }
 
-        assert link_locations == expected_links, (item, item.name)
+        assert link_locations == expected_links_rel, (item, item.name)
 
 
 def test_link_with_context(copy_fortran_file):
@@ -1154,7 +1160,10 @@ def test_link_with_context(copy_fortran_file):
 
         for link in docstring("a"):
             assert link.string in expected_links, (item, item.name, link)
-            assert link.get("href", None) == expected_links[link.string], (
+            base_dir = pathlib.Path(item.get_url()).parent
+            expected_link = relpath(expected_links[link.string], base_dir)
+
+            assert link.get("href", None) == expected_link, (
                 item,
                 item.name,
                 link.string,
@@ -1286,5 +1295,5 @@ def test_links_in_deferred_bound_methods(copy_fortran_file):
         project.modules[0].types[0].boundprocs[0].doc, features="html.parser"
     )
     links = {link.text: link["href"] for link in docstring.find_all("a")}
-    assert links["foo_t"].endswith("type/foo_t.html")
-    assert links["foo"].endswith("type/foo_t.html#boundprocedure-foo")
+    assert links["foo_t"].endswith("foo_t.html")
+    assert links["foo"].endswith("foo_t.html#boundprocedure-foo")

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1077,17 +1077,17 @@ def test_make_links(copy_fortran_file):
     settings = copy_fortran_file(data)
     project = create_project(settings)
     md = MetaMarkdown(project=project)
-    project.markdown(md, "..")
+    project.markdown(md)
 
     expected_links = {
-        "a": "../module/a.html",
-        "b": "../type/b.html",
-        "c": "../type/b.html#variable-c",
-        "d": "../proc/d.html",
-        "e": "../type/b.html#boundprocedure-e",
-        "f": "../proc/f.html",
-        "g": "../module/a.html#variable-g",
-        "h": "../program/h.html",
+        "a": "module/a.html",
+        "b": "type/b.html",
+        "c": "type/b.html#variable-c",
+        "d": "proc/d.html",
+        "e": "type/b.html#boundprocedure-e",
+        "f": "proc/f.html",
+        "g": "module/a.html#variable-g",
+        "h": "program/h.html",
     }
 
     for item in chain(
@@ -1129,19 +1129,19 @@ def test_link_with_context(copy_fortran_file):
     settings.proc_internals = True
     project = create_project(settings)
     md = MetaMarkdown(project=project)
-    project.markdown(md, "..")
+    project.markdown(md)
 
     expected_links = {
-        "a": "../module/a.html",
-        "b": "../type/b.html",
-        "c": "../type/b.html#variable-c",
-        "d": "../proc/d.html",
-        "e": "../type/b.html#boundprocedure-e",
-        "f": "../proc/d.html#proc-f",
-        "g": "../module/a.html#variable-g",
-        "h": "../program/h.html",
-        "i": "../proc/d.html#variable-i",
-        "x": "../proc/d.html#variable-x",
+        "a": "module/a.html",
+        "b": "type/b.html",
+        "c": "type/b.html#variable-c",
+        "d": "proc/d.html",
+        "e": "type/b.html#boundprocedure-e",
+        "f": "proc/d.html#proc-f",
+        "g": "module/a.html#variable-g",
+        "h": "program/h.html",
+        "i": "proc/d.html#variable-i",
+        "x": "proc/d.html#variable-x",
     }
 
     for item in chain(

--- a/test/test_projects/test_external_project.py
+++ b/test/test_projects/test_external_project.py
@@ -138,7 +138,8 @@ def test_external_project(external_project):
     top_level_project, _ = external_project
 
     # Read generated HTML
-    with open(top_level_project / "doc/program/top_level.html", "r") as f:
+    program_dir = top_level_project / "doc/program"
+    with open(program_dir / "top_level.html", "r") as f:
         top_program_html = BeautifulSoup(f.read(), features="html.parser")
 
     # Find links to external modules
@@ -150,7 +151,8 @@ def test_external_project(external_project):
     assert len(links) == 3
     assert "external_module" in links
     local_url = urlparse(links["external_module"])
-    assert pathlib.Path(local_url.path).is_file()
+    local_path = program_dir / local_url.path
+    assert local_path.is_file()
 
     assert "remote_module" in links
     remote_url = urlparse(links["remote_module"])
@@ -163,7 +165,8 @@ def test_procedure_module_use_links_(external_project):
     top_level_project, _ = external_project
 
     # Read generated HTML
-    with open(top_level_project / "doc/proc/abortcriteria_load.html", "r") as f:
+    proc_dir = top_level_project / "doc/proc"
+    with open(proc_dir/ "abortcriteria_load.html", "r") as f:
         procedure_html = BeautifulSoup(f.read(), features="html.parser")
 
     # Find links to external modules
@@ -175,4 +178,5 @@ def test_procedure_module_use_links_(external_project):
     assert len(links) == 1
     assert "external_module" in links
     local_url = urlparse(links["external_module"])
-    assert pathlib.Path(local_url.path).is_file()
+    local_path = proc_dir / local_url.path
+    assert local_path.is_file()

--- a/test/test_projects/test_external_project.py
+++ b/test/test_projects/test_external_project.py
@@ -166,7 +166,7 @@ def test_procedure_module_use_links_(external_project):
 
     # Read generated HTML
     proc_dir = top_level_project / "doc/proc"
-    with open(proc_dir/ "abortcriteria_load.html", "r") as f:
+    with open(proc_dir / "abortcriteria_load.html", "r") as f:
         procedure_html = BeautifulSoup(f.read(), features="html.parser")
 
     # Find links to external modules

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -1774,45 +1774,33 @@ def test_url(parse_fortran_file):
     """
 
     fortran_file = parse_fortran_file(data)
+    program = fortran_file.programs[0]
+    module = fortran_file.modules[0]
+    submodule = fortran_file.submodules[0]
 
-    assert fortran_file.programs[0].get_dir() == "program"
-    assert fortran_file.modules[0].get_dir() == "module"
-    assert fortran_file.submodules[0].get_dir() == "module"
-    assert fortran_file.programs[0].subroutines[0].get_dir() == "proc"
-    assert fortran_file.programs[0].functions[0].get_dir() == "proc"
-    assert fortran_file.modules[0].subroutines[0].get_dir() == "proc"
-    assert fortran_file.modules[0].interfaces[0].get_dir() == "interface"
-    assert fortran_file.programs[0].variables[0].get_dir() is None
-    assert fortran_file.modules[0].variables[0].get_dir() is None
-    assert fortran_file.modules[0].enums[0].get_dir() is None
+    assert program.get_dir() == "program"
+    assert module.get_dir() == "module"
+    assert submodule.get_dir() == "module"
+    assert program.subroutines[0].get_dir() == "proc"
+    assert program.functions[0].get_dir() == "proc"
+    assert module.subroutines[0].get_dir() == "proc"
+    assert module.interfaces[0].get_dir() == "interface"
+    assert program.variables[0].get_dir() is None
+    assert module.variables[0].get_dir() is None
+    assert module.enums[0].get_dir() is None
 
-    assert fortran_file.programs[0].get_url().endswith("/program/prog_foo.html")
-    assert fortran_file.modules[0].get_url().endswith("/module/mod_foo.html")
-    assert fortran_file.submodules[0].get_url().endswith("/module/submod_foo.html")
-    assert (
-        fortran_file.programs[0].subroutines[0].get_url().endswith("/proc/sub_foo.html")
+    assert program.full_url.endswith("program/prog_foo.html")
+    assert module.full_url.endswith("module/mod_foo.html")
+    assert submodule.full_url.endswith("module/submod_foo.html")
+    assert program.subroutines[0].full_url.endswith("proc/sub_foo.html")
+    assert program.functions[0].full_url.endswith("proc/func_foo.html")
+    assert module.subroutines[0].full_url.endswith("proc/foo1.html")
+    assert module.interfaces[0].full_url.endswith("interface/inter_foo.html")
+    assert program.variables[0].full_url.endswith(
+        "program/prog_foo.html#variable-int_foo"
     )
-    assert (
-        fortran_file.programs[0].functions[0].get_url().endswith("/proc/func_foo.html")
-    )
-    assert fortran_file.modules[0].subroutines[0].get_url().endswith("/proc/foo1.html")
-    assert (
-        fortran_file.modules[0]
-        .interfaces[0]
-        .get_url()
-        .endswith("/interface/inter_foo.html")
-    )
-    assert (
-        fortran_file.programs[0]
-        .variables[0]
-        .get_url()
-        .endswith("/program/prog_foo.html#variable-int_foo")
-    )
-    assert (
-        fortran_file.modules[0]
-        .variables[0]
-        .get_url()
-        .endswith("/module/mod_foo.html#variable-real_foo")
+    assert module.variables[0].full_url.endswith(
+        "module/mod_foo.html#variable-real_foo"
     )
 
 


### PR DESCRIPTION
Replacement for #593 which ended up using a slow semi-brute force method. Instead, ensure `project_url` in templates is relative to current page when loading template, and pass every entity link through a relative-url filter.

Fixes #581 

@amorison hopefully this is better, fixing all the links without the massive slowdown