### PR TITLE
Fix broken relative links

### DIFF
--- a/example/src/ford_test_module.fpp
+++ b/example/src/ford_test_module.fpp
@@ -20,7 +20,7 @@ contains
 
 #ifdef HAS_DECREMENT
   subroutine decrement(x)
-    !! Decrease argument by one
+    !! Decrease argument by one, the opposite of [[increment]]
     !!
     !! Only publicly accessible if `"HAS_DECREMENT"` preprocessor
     !! macro is defined

--- a/ford/_markdown.py
+++ b/ford/_markdown.py
@@ -117,7 +117,15 @@ class MetaMarkdown(Markdown):
             and context is not None
             and (url := context.get_url()) is not None
         ):
-            self.current_path = self.base_url / Path(url).parent
+            # This is a bit of a pain, but when making `[[ford]]` links, we want
+            # the link to be relative to the page the link is from. However, we
+            # use the entity description both on the entity page, and the list
+            # pages, so the same relative url needs to work from both. Luckily
+            # we know the directory layout, so just make a relative link from a
+            # (non-existent) sibling directory
+            self.current_path = (
+                self.base_url / Path(url).parent.parent / "non-existent dir"
+            )
         else:
             self.current_path = path
         return super().convert(source)

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -178,7 +178,7 @@ class ProjectSettings:
     predocmark: str = ">"
     predocmark_alt: str = "|"
     preprocess: bool = True
-    preprocessor: str = "pcpp -D__GFORTRAN__"
+    preprocessor: str = "pcpp -D__GFORTRAN__ --passthru-comments"
     print_creation_date: bool = False
     privacy_policy_url: Optional[str] = None
     proc_internals: bool = False

--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -98,7 +98,7 @@
                 </li>
               {% elif project.programs|length == 1 %}
                 <li class="nav-item">
-                  <a class="nav-link" href="{{ project.programs[0].get_url() }}">Program</a>
+                  <a class="nav-link" href="{{ project_url }}/{{ project.programs[0].get_url() }}">Program</a>
                 </li>
               {% endif %}
               {% if privacy_policy_url %}

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1082,14 +1082,14 @@ def test_make_links(copy_fortran_file):
     project.markdown(md)
 
     expected_links = {
-        "a": "module/a.html",
-        "b": "type/b.html",
-        "c": "type/b.html#variable-c",
-        "d": "proc/d.html",
-        "e": "type/b.html#boundprocedure-e",
-        "f": "proc/f.html",
-        "g": "module/a.html#variable-g",
-        "h": "program/h.html",
+        "a": "../module/a.html",
+        "b": "../type/b.html",
+        "c": "../type/b.html#variable-c",
+        "d": "../proc/d.html",
+        "e": "../type/b.html#boundprocedure-e",
+        "f": "../proc/f.html",
+        "g": "../module/a.html#variable-g",
+        "h": "../program/h.html",
     }
 
     for item in chain(
@@ -1100,12 +1100,8 @@ def test_make_links(copy_fortran_file):
     ):
         docstring = BeautifulSoup(item.doc, features="html.parser")
         link_locations = {a.string: a.get("href", None) for a in docstring("a")}
-        base_dir = pathlib.Path(item.get_url()).parent
-        expected_links_rel = {
-            k: relpath(v, base_dir) for k, v in expected_links.items()
-        }
 
-        assert link_locations == expected_links_rel, (item, item.name)
+        assert link_locations == expected_links, (item, item.name)
 
 
 def test_link_with_context(copy_fortran_file):
@@ -1138,16 +1134,16 @@ def test_link_with_context(copy_fortran_file):
     project.markdown(md)
 
     expected_links = {
-        "a": "module/a.html",
-        "b": "type/b.html",
-        "c": "type/b.html#variable-c",
-        "d": "proc/d.html",
-        "e": "type/b.html#boundprocedure-e",
-        "f": "proc/d.html#proc-f",
-        "g": "module/a.html#variable-g",
-        "h": "program/h.html",
-        "i": "proc/d.html#variable-i",
-        "x": "proc/d.html#variable-x",
+        "a": "../module/a.html",
+        "b": "../type/b.html",
+        "c": "../type/b.html#variable-c",
+        "d": "../proc/d.html",
+        "e": "../type/b.html#boundprocedure-e",
+        "f": "../proc/d.html#proc-f",
+        "g": "../module/a.html#variable-g",
+        "h": "../program/h.html",
+        "i": "../proc/d.html#variable-i",
+        "x": "../proc/d.html#variable-x",
     }
 
     for item in chain(
@@ -1160,8 +1156,7 @@ def test_link_with_context(copy_fortran_file):
 
         for link in docstring("a"):
             assert link.string in expected_links, (item, item.name, link)
-            base_dir = pathlib.Path(item.get_url()).parent
-            expected_link = relpath(expected_links[link.string], base_dir)
+            expected_link = expected_links[link.string]
 
             assert link.get("href", None) == expected_link, (
                 item,

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -10,6 +10,7 @@ import re
 
 import ford.reader as reader
 from ford.reader import _contains_unterminated_string
+from ford.settings import ProjectSettings
 
 RE_WHITE = re.compile(r"\s+")
 
@@ -204,3 +205,19 @@ def test_preprocessor_warning(copy_fortran_file):
         )
     )
     assert "foo" in lines
+
+
+def test_preprocessor_leaves_urls(copy_fortran_file):
+    """Check preprocessor leaves urls, issue #611"""
+
+    data = """\
+    !! http://www.example.com
+    module foo
+    end
+    """
+    filename = copy_fortran_file(data, ".F90")
+    preprocessor = ProjectSettings().preprocessor.split()
+    lines = "\n".join(
+        list(reader.FortranReader(str(filename), preprocessor=preprocessor))
+    )
+    assert "http://www.example.com" in lines


### PR DESCRIPTION
Fix a few issues around links:

- `[[ford]]` style links in entity summaries on list pages
- nav bar link to single program in project
- `pcpp` preprocessor parsing `http://` as ending in a comment and breaking urls

Fixes #611
Fixes #612 
Fixes #613 