### PR TITLE
fix: Handle zero-length tuple during exception handling within `Project.__init__()`

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -182,7 +182,7 @@ class Project:
                 if not settings.dbg:
                     raise e
 
-                warn(f"Error parsing {relative_path}.\n\t{e.args[0]}")
+                warn(f"Error parsing {relative_path}.\n\t{e.args if len(e.args) == 0 else e.args[0]}")
                 continue
 
     def _fortran_file(


### PR DESCRIPTION
fixes #618