### PR TITLE
Fix type definition in `block` breaking parent scope

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -860,7 +860,7 @@ class FortranContainer(FortranBase):
                     blocklevel -= 1
                 elif endtype and endtype.lower() == "associate":
                     associations.remove_last_batch()
-                else:
+                elif blocklevel == 0:
                     self._cleanup()
                     return
 

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -2238,3 +2238,21 @@ def test_associate_array(parse_fortran_file):
 
     # Just check we can parse ok
     parse_fortran_file(data)
+
+
+def test_blocks_with_type(parse_fortran_file):
+    data = """\
+    module foo
+    contains
+      subroutine sub1()
+        block
+          type :: t1
+          end type t1
+        end block
+      end subroutine sub1
+    end module foo
+    """
+
+    source = parse_fortran_file(data)
+    module = source.modules[0]
+    assert len(module.subroutines) == 1


### PR DESCRIPTION
Fixes #638