### PR TITLE
Small cleanup of frontpage template

### DIFF
--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -132,7 +132,11 @@
     <footer>
       <div class="container">
         <div class="row justify-content-between">
-          <div class="col"><p>{{ project }} was developed by {{ author }}<br>&copy; {{ year }} {{ license }}
+          <div class="col">
+            <p>
+              {{ project }}
+              {% if author %} was developed by {{ author }}<br>{% endif %}
+              &copy; {{ year }} {{ license }}
               {% if revision %}<br /><small>{{ revision }}</small>{% endif %}</p>
           </div>
           <div class="col">

--- a/ford/templates/block_page.html
+++ b/ford/templates/block_page.html
@@ -22,7 +22,7 @@
     {{ blockdat.doc }}
     <br>
 
-    {% if blockdat.common|length > 0 %}
+    {% if blockdat.common %}
     <section>
       <h2>Common Blocks</h2>
       {% for com in blockdat.common %}
@@ -37,7 +37,7 @@
     </script>
     {% endif %}
 
-    {% if blockdat.variables|length > 0 %}
+    {% if blockdat.variables %}
     <section>
     <h2>Variables</h2>
     {{ macros.variable_list(blockdat.variables) }}
@@ -45,7 +45,7 @@
     <br>
     {% endif %}
     
-    {% if blockdat.types|length > 0 %}
+    {% if blockdat.types %}
     <section>
      <h2>Derived Types</h2>
    {% for type in blockdat.types %}

--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -1,32 +1,35 @@
 {% extends "base.html" %}
 {% block body %}
-      <!-- Main component for a primary marketing message or call to action -->
-      <div class="p-5 mb-4 bg-light border rounded-3" id="jumbotron">
-        {{ summary }}
-        	 {% if project_github or project_bitbucket or project_gitlab or project_sourceforge or project_website %}
-	<p> Find us on&hellip;</p>
-        <p>
-			 {% if project_github %}
+  <!-- Main component for a primary marketing message or call to action -->
+  {% set project_links = project_github or project_bitbucket or project_gitlab or project_sourceforge or project_website %}
+  {% if summary or project_links or project_download %}
+    <div class="p-5 mb-4 bg-light border rounded-3" id="jumbotron">
+      {{ summary }}
+      {% if project_links %}
+	    <p> Find us on&hellip;</p>
+      <p>
+	    {% if project_github %}
           <a class="btn btn-lg btn-primary" href="{{ project_github }}" role="button">GitHub</a>
-			 {% endif %}
-			 {% if project_gitlab %}
+	    {% endif %}
+	    {% if project_gitlab %}
           <a class="btn btn-lg btn-primary" href="{{ project_gitlab }}" role="button">The Web</a>
-			 {% endif %}
-			 {% if project_bitbucket %}
+	    {% endif %}
+	    {% if project_bitbucket %}
           <a class="btn btn-lg btn-primary" href="{{ project_bitbucket }}" role="button">Bitbucket</a>
-			 {% endif %}
-			 {% if project_sourceforge %}
+	    {% endif %}
+	    {% if project_sourceforge %}
           <a class="btn btn-lg btn-primary" href="{{ project_sourceforge }}" role="button">Sourceforge</a>
-			 {% endif %}
-			 {% if project_website %}
+	    {% endif %}
+	    {% if project_website %}
           <a class="btn btn-lg btn-primary" href="{{ project_website }}" role="button">The Web</a>
-			 {% endif %}
-	         {% endif %}
-			 {% if project_download %}
-          <a class="btn btn-lg btn-danger" style="float:right" href="{{ project_download }}" role="button">Download the Source</a>
-			 {% endif %}
-        </p>
-      </div>
+	    {% endif %}
+	  {% endif %}
+	  {% if project_download %}
+        <a class="btn btn-lg btn-danger" style="float:right" href="{{ project_download }}" role="button">Download the Source</a>
+	  {% endif %}
+      </p>
+    </div>
+  {% endif %}
 
       <div class="row" id='text'>
 		{% set col = "col-md-8" if author else "col-md-12"%}

--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -71,9 +71,9 @@
       </div>
       {% set count=0 %}
       {% if incl_src %}{% set count = count + 1 %}{% endif %}
-      {% if project.modules|length > 0 %}{% set count = count + 1 %}{% endif %}
-      {% if project.procedures|length > 0 %}{% set count = count + 1 %}{% endif %}
-      {% if project.types|length > 0 %}{% set count = count + 1 %}{% endif %}
+      {% if project.modules %}{% set count = count + 1 %}{% endif %}
+      {% if project.procedures %}{% set count = count + 1 %}{% endif %}
+      {% if project.types %}{% set count = count + 1 %}{% endif %}
       {% set max_length = max_frontpage_items|int %}
       {% if count and max_length %}
         {% set width = (12/count)|int %}
@@ -96,7 +96,7 @@
             </div>
           </div>
           {% endif %}
-          {% if project.modules|length > 0 %}
+          {% if project.modules %}
           <div class="col-xs-6 col-sm-{{ width }}">
             <div>
               <h3>Modules</h3>
@@ -113,7 +113,7 @@
             </div>
           </div>
           {% endif %}
-          {% if project.procedures|length > 0 %}
+          {% if project.procedures %}
           <div class="col-xs-6 col-sm-{{ width }}">
             <div>
               <h3>Procedures</h3>
@@ -130,7 +130,7 @@
             </div>
           </div>
           {% endif %}
-          {% if project.types|length > 0 %}
+          {% if project.types %}
           <div class="col-xs-6 col-sm-{{ width }}">
             <div>
               <h3>Derived Types</h3>

--- a/ford/templates/index.html
+++ b/ford/templates/index.html
@@ -1,3 +1,17 @@
+{% macro project_link_button(address, name) %}
+  {# Optional button in jumbtron for project link #}
+  {%- if address -%}
+    <a class="btn btn-lg btn-primary" href="{{ address }}" role="button">{{ name }}</a>
+  {%- endif -%}
+{% endmacro %}
+
+{% macro dev_link_button(address, icon) %}
+  {# Optional button in sidebar for developer link #}
+  {%- if address -%}
+    <a class="btn btn-lg btn-primary" href="{{ address }}"><i class="fa {{ icon }} fa-lg"></i></a>
+  {%- endif -%}
+{% endmacro %}
+
 {% extends "base.html" %}
 {% block body %}
   <!-- Main component for a primary marketing message or call to action -->
@@ -6,75 +20,49 @@
     <div class="p-5 mb-4 bg-light border rounded-3" id="jumbotron">
       {{ summary }}
       {% if project_links %}
-	    <p> Find us on&hellip;</p>
+        <p> Find us on&hellip;</p>
       <p>
-	    {% if project_github %}
-          <a class="btn btn-lg btn-primary" href="{{ project_github }}" role="button">GitHub</a>
-	    {% endif %}
-	    {% if project_gitlab %}
-          <a class="btn btn-lg btn-primary" href="{{ project_gitlab }}" role="button">The Web</a>
-	    {% endif %}
-	    {% if project_bitbucket %}
-          <a class="btn btn-lg btn-primary" href="{{ project_bitbucket }}" role="button">Bitbucket</a>
-	    {% endif %}
-	    {% if project_sourceforge %}
-          <a class="btn btn-lg btn-primary" href="{{ project_sourceforge }}" role="button">Sourceforge</a>
-	    {% endif %}
-	    {% if project_website %}
-          <a class="btn btn-lg btn-primary" href="{{ project_website }}" role="button">The Web</a>
-	    {% endif %}
-	  {% endif %}
-	  {% if project_download %}
+        {{ project_link_button(project_github, "GitHub") }}
+        {{ project_link_button(project_gitlab, "Gitlab") }}
+        {{ project_link_button(project_bitbucket, "Bitbucket") }}
+        {{ project_link_button(project_sourceforge, "Sourceforge") }}
+        {{ project_link_button(project_website, "The Web") }}
+      {% endif %}
+      {% if project_download %}
         <a class="btn btn-lg btn-danger" style="float:right" href="{{ project_download }}" role="button">Download the Source</a>
-	  {% endif %}
+      {% endif %}
       </p>
     </div>
   {% endif %}
 
       <div class="row" id='text'>
-		{% set col = "col-md-8" if author else "col-md-12"%}
+        {% set col = "col-md-8" if author else "col-md-12"%}
         <div class={{ col }}>
           <h1>{{ project }}</h1>
           {{ proj_docs }}
         </div>
-		{% if author %}
+        {% if author %}
           <div class="col-md-4">
-	        <div class="card card-body bg-light">
+            <div class="card card-body bg-light">
               {% if author_pic %}
-     		    <img src="{{ author_pic }}" alt="Developer picture" class="card-img-top">
-    		  {% endif %}
+                <img src="{{ author_pic }}" alt="Developer picture" class="card-img-top">
+              {% endif %}
               <h2 class="card-title">Developer Info</h2>
               <h4 class="card-text">{{ author }}</h4>
               <p class="card-text">{{ author_description }}</p>
-			  {% if github or bitbucket or facebook or twitter or google_plus or linkedin or email or website %}
+              {% if github or bitbucket or facebook or twitter or google_plus or linkedin or email or website %}
                 <div class="text-center"><div class="btn-group" role="group">
                     {% if email %}
                       <a class="btn btn-lg btn-primary" href="mailto:{{ email }}"><i class="fa fa-envelope fa-lg"></i></a>
                     {% endif %}
-                    {% if website %}
-                      <a class="btn btn-lg btn-primary" href="{{ website }}"><i class="fa fa-globe fa-lg"></i></a>
-                    {% endif %}
-                    {% if github %}
-                      <a class="btn btn-lg btn-primary" href="{{ github }}"><i class="fa fa-github fa-lg"></i></a>
-                    {% endif %}
-                    {% if gitlab %}
-                      <a class="btn btn-lg btn-primary" href="{{ gitlab }}"><i class="fa fa-gitlab fa-lg"></i></a>
-				    {% endif %}
-				    {% if bitbucket %}
-                      <a class="btn btn-lg btn-primary" href="{{ bitbucket }}"><i class="fa fa-bitbucket fa-lg"></i></a>
-                    {% endif %}
-                    {% if facebook %}
-                      <a class="btn btn-lg btn-primary" href="{{ facebook }}"><i class="fa fa-facebook fa-lg"></i></a>
-				    {% endif %}
-                    {% if google_plus %}
-                      <a class="btn btn-lg btn-primary" href="{{ google_plus }}"><i class="fa fa-google-plus fa-lg"></i></a>
-				    {% endif %}
-                    {% if linkedin %}
-                      <a class="btn btn-lg btn-primary" href="{{ linkedin }}"><i class="fa fa-linkedin fa-lg"></i></a>
-				    {% endif %}
-                    {% if twitter %}
-                      <a class="btn btn-lg btn-primary" href="{{ twitter }}"><i class="fa fa-twitter fa-lg"></i></a>
-				    {% endif %}
+                    {{ dev_link_button(website, "fa-globe") }}
+                    {{ dev_link_button(github, "fa-github") }}
+                    {{ dev_link_button(gitlab, "fa-gitlab") }}
+                    {{ dev_link_button(bitbucket, "fa-bitbucket") }}
+                    {{ dev_link_button(facebook, "fa-facebook") }}
+                    {{ dev_link_button(google_plus, "fa-google-plus") }}
+                    {{ dev_link_button(linkedin, "fa-linkedin") }}
+                    {{ dev_link_button(twitter, "fa-twitter") }}
                 </div></div>
               {% endif %}
             </div>
@@ -162,4 +150,3 @@
         </div>
       {% endif %}
 {% endblock body %}
-

--- a/ford/templates/nongenint_page.html
+++ b/ford/templates/nongenint_page.html
@@ -63,7 +63,7 @@
     {{ macros.use_list(interface) }}
 
     <h3>Arguments</h3>
-    {% if procedure.args|length > 0 %}
+    {% if procedure.args %}
       {{ macros.variable_list(procedure.args, intent=True) }}
     {% else %}
       <em>None</em>
@@ -74,7 +74,7 @@
     {% if var.kind %}{% set args = args + 1 %}{% endif %}
     {% if var.strlen %}{% set args = args + 1 %}{% endif %}
     {% if var.proto %}{% set args = args + 1 %}{% endif %}
-      <h3>Return Value <span class="anchor" id="{{ var.anchor }}"></span><small>{{ var.vartype }}{% if args > 0 -%}({% if var.kind -%}kind={{ var.kind }}{%- endif %}{% if args > 1 -%},{%- endif %}{% if var.strlen -%}len={{ var.strlen }}{%- endif %}{% if var.proto -%}{% if not var.proto[0].permission or var.proto[0].visible -%}{{ var.proto[0] }}{% else %}{{ var.proto[0].name }}{%- endif %}{{ var.proto[1] }}{%- endif %}){%- endif %}{% if var.attribs|length > 0 -%},{%- endif %}
+      <h3>Return Value <span class="anchor" id="{{ var.anchor }}"></span><small>{{ var.vartype }}{% if args > 0 -%}({% if var.kind -%}kind={{ var.kind }}{%- endif %}{% if args > 1 -%},{%- endif %}{% if var.strlen -%}len={{ var.strlen }}{%- endif %}{% if var.proto -%}{% if not var.proto[0].permission or var.proto[0].visible -%}{{ var.proto[0] }}{% else %}{{ var.proto[0].name }}{%- endif %}{{ var.proto[1] }}{%- endif %}){%- endif %}{% if var.attribs -%},{%- endif %}
   {% for attrib in var.attribs -%}{{ attrib }}{% if not loop.last or var.dimension -%}, {%- endif %}{%- endfor %}{{ var.dimension }}</small></h3>
     {{ var.doc }}
     {% endif %}

--- a/ford/templates/proc_page.html
+++ b/ford/templates/proc_page.html
@@ -32,7 +32,7 @@
     {% endif %}
 
     <h3>Arguments</h3>
-    {% if procedure.args|length > 0 %}
+    {% if procedure.args %}
       {{ macros.variable_list(procedure.args, intent=True) }}
     {% else %}
     <em>None</em>
@@ -72,7 +72,7 @@
      {% endif %}
     <br>
 
-    {% if procedure.common|length > 0 %}
+    {% if procedure.common %}
     <section>
       <h2>Common Blocks</h2>
       {% for com in procedure.common %}
@@ -87,7 +87,7 @@
     </script>
     {% endif %}
 
-    {% if procedure.variables|length > 0 %}
+    {% if procedure.variables %}
     <section>    
       <h2>Variables</h2>
     {{ macros.variable_list(procedure.variables, permission=True) }}
@@ -95,7 +95,7 @@
     <br>
     {% endif %}
     
-    {% if procedure.enums|length > 0 %}
+    {% if procedure.enums %}
     <section>
     <h2>Enumerations</h2>
     {% for enum in procedure.enums %}
@@ -105,7 +105,7 @@
     <br>
     {% endif %}
     
-    {% if procedure.interfaces|length > 0 %}
+    {% if procedure.interfaces %}
   <section> 
      <h2>Interfaces</h2>
    {% for intr in procedure.interfaces %}
@@ -115,7 +115,7 @@
    <br>
     {% endif %}
 
-    {% if procedure.absinterfaces|length > 0 %}
+    {% if procedure.absinterfaces %}
     <section>
    <h2>Abstract Interfaces</h2>
    {% for intr in procedure.absinterfaces %}
@@ -125,7 +125,7 @@
    <br>
     {% endif %}
     
-    {% if procedure.types|length > 0 %}
+    {% if procedure.types %}
     <section>
    <h2>Derived Types</h2>
    {% for type in procedure.types %}
@@ -135,7 +135,7 @@
    <br>
     {% endif %}
     
-    {% if procedure.functions|length > 0 %} 
+    {% if procedure.functions %} 
     <section>
     <h2>Functions</h2>
     {% for proc in procedure.functions %}
@@ -146,7 +146,7 @@
     {% endif %}
 
 
-    {% if procedure.subroutines|length > 0 %}
+    {% if procedure.subroutines %}
     <section>
     <h2>Subroutines</h2>
     {% for proc in procedure.subroutines %}

--- a/ford/templates/prog_page.html
+++ b/ford/templates/prog_page.html
@@ -33,7 +33,7 @@
      {% endif %}
     {% if program.doc or program.callsgraph %}<br>{% endif %}
 
-     {% if program.common|length > 0 %}
+     {% if program.common %}
      <section>
        <h2>Common Blocks</h2>
        {% for com in program.common %}
@@ -48,7 +48,7 @@
      </script>
      {% endif %}
 
-    {% if program.variables|length > 0 %}
+    {% if program.variables %}
     <section>
     <h2>Variables</h2>
     {{ macros.variable_list(program.variables) }}
@@ -56,7 +56,7 @@
     <br>
     {% endif %}
     
-    {% if program.enums|length > 0 %}
+    {% if program.enums %}
     <section>
     <h2>Enumerations</h2>
     {% for enum in program.enums %}
@@ -66,7 +66,7 @@
     <br>
     {% endif %}
     
-    {% if program.interfaces|length > 0 %}
+    {% if program.interfaces %}
     <section>
    <h2>Interfaces</h2>
    {% for intr in program.interfaces %}
@@ -76,7 +76,7 @@
    <br>
     {% endif %}
     
-    {% if program.absinterfaces|length > 0 %}
+    {% if program.absinterfaces %}
     <section>
    <h2>Abstract Interfaces</h2>
    {% for intr in program.absinterfaces %}
@@ -86,7 +86,7 @@
    <br>
     {% endif %}
 
-    {% if program.types|length > 0 %}
+    {% if program.types %}
     <section>
    <h2>Derived Types</h2>
    {% for type in program.types %}
@@ -96,7 +96,7 @@
    <br>
     {% endif %}
     
-    {% if program.functions|length > 0 %} 
+    {% if program.functions %} 
     <section>
     <h2>Functions</h2>
     {% for proc in program.functions %}
@@ -107,7 +107,7 @@
     {% endif %}
 
 
-    {% if program.subroutines|length > 0 %}
+    {% if program.subroutines %}
     <section>
     <h2>Subroutines</h2>
     {% for proc in program.subroutines %}

--- a/ford/templates/type_page.html
+++ b/ford/templates/type_page.html
@@ -49,7 +49,7 @@
     {% endif %}
     <br>
 
-    {% if dtype.variables|length > 0 %}
+    {% if dtype.variables %}
     <section>
     <h2>Components</h2>
     {{ macros.variable_list(dtype.variables, permission=True) }}


### PR DESCRIPTION
- Fix empty jumbtron and odd footer if no author or summary provided (see #633)
- Add some macros to simplify buttons
- Remove `|length > 0` from jinja templates