### PR TITLE
Fix bug with `hide_undoc = True`

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -605,7 +605,7 @@ class FortranBase:
 
     def _should_display(self, item) -> bool:
         """Return True if item should be displayed"""
-        if self.settings.hide_undoc and not item.doc:
+        if self.settings.hide_undoc and not len(item.doc_list)>0:
             return False
         return item.permission in self.display
 

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -605,7 +605,7 @@ class FortranBase:
 
     def _should_display(self, item) -> bool:
         """Return True if item should be displayed"""
-        if self.settings.hide_undoc and not len(item.doc_list)>0:
+        if self.settings.hide_undoc and not item.doc_list:
             return False
         return item.permission in self.display
 

--- a/test/test_project.py
+++ b/test/test_project.py
@@ -1362,3 +1362,23 @@ def test_links_in_deferred_bound_methods(copy_fortran_file):
     links = {link.text: link["href"] for link in docstring.find_all("a")}
     assert links["foo_t"].endswith("foo_t.html")
     assert links["foo"].endswith("foo_t.html#boundprocedure-foo")
+
+
+def test_hide_undoc(copy_fortran_file):
+    data = """\
+    module foo
+    contains
+      !> A subroutine with a docstring
+      subroutine with_doc
+      end subroutine with_doc
+
+      subroutine no_doc
+      end subroutine no_doc
+    end module
+    """
+
+    settings = copy_fortran_file(data)
+    settings.hide_undoc = True
+    project = create_project(settings)
+
+    assert len(project.modules[0].subroutines) == 1


### PR DESCRIPTION
The `hide_undoc` flag didn't work correctly. When running FORD on a project with the `hide_undoc` flag set to `true`, FORD crashes with the following traceback:
```
Traceback (most recent call last):
  File "/home/thundermoose/ExternalGits/ford/ford.py", line 7, in <module>
    run()
  File "/home/thundermoose/ExternalGits/ford/ford/__init__.py", line 489, in run
    main(proj_data, proj_docs)
  File "/home/thundermoose/ExternalGits/ford/ford/__init__.py", line 420, in main
    project.correlate()
  File "/home/thundermoose/ExternalGits/ford/ford/fortran_project.py", line 343, in correlate
    container.prune()
  File "/home/thundermoose/ExternalGits/ford/ford/sourceform.py", line 1415, in prune
    self.functions = self.filter_display(self.functions)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thundermoose/ExternalGits/ford/ford/sourceform.py", line 615, in filter_display
    return [obj for obj in collection if self._should_display(obj)]
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/thundermoose/ExternalGits/ford/ford/sourceform.py", line 608, in _should_display
    if self.settings.hide_undoc and not item.doc:
                                        ^^^^^^^^
AttributeError: 'FortranFunction' object has no attribute 'doc'
```
The reason this happen is that the `project.correlate()` function is called before the `project.markdown(md)` line where the `doc` attributes are setup. Switching order of these lines is not possible since the markdown parser `md` depend on `project.correlate()`. The solution was simple, check if the `doc_list` attribute is non-empty instead of checking for the `doc` attribute. Perhaps I should check if the items in the doc_list are not empty strings as well?