### PR TITLE
Fix `namelist` page title

### DIFF
--- a/ford/templates/namelist_page.html
+++ b/ford/templates/namelist_page.html
@@ -3,7 +3,7 @@
 {% extends "base.html" %}
 
 {% block title %}
-  {{ namelist.name }} %ndash; {{ project }}
+  {{ namelist.name }} &ndash; {{ project }}
 {% endblock title %}
 
 {% block body %}


### PR DESCRIPTION
The pull request replaces `%ndash;` with `&ndash;` in the title of the template.