### PR TITLE
Fix issue with no whitespace between type and `function`

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -661,7 +661,7 @@ class FortranContainer(FortranBase):
         re.IGNORECASE | re.VERBOSE,
     )
     FUNCTION_RE = re.compile(
-        r"""^(?:(?P<attributes>.+?)\s+)?               # Optional attributes (including type)
+        r"""^(?:(?P<attributes>.+?)\s*)?               # Optional attributes (including type)
         function\s+(?P<name>\w+)\s*                    # Required function name
         (?P<arguments>\([^()]*\))?                     # Required arguments
         (?=(?:.*result\s*\(\s*(?P<result>\w+)\s*\))?)  # Optional result name

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -2256,3 +2256,15 @@ def test_blocks_with_type(parse_fortran_file):
     source = parse_fortran_file(data)
     module = source.modules[0]
     assert len(module.subroutines) == 1
+
+
+def test_no_space_after_character_type(parse_fortran_file):
+    data = """\
+    CHARACTER(LEN=250)FUNCTION FirstWord( sString ) RESULT( sRes )
+        CHARACTER(LEN=250)sString
+    END FUNCTION FirstWord
+    """
+
+    source = parse_fortran_file(data)
+    function = source.functions[0]
+    assert function.name.lower() == "firstword"


### PR DESCRIPTION
This probably actually too loose, but seems to work ok

Related to #475 