### PR TITLE
Fix error detection when parsing `extra_filetype`

### DIFF
--- a/ford/settings.py
+++ b/ford/settings.py
@@ -104,7 +104,7 @@ class ExtraFileType:
     @classmethod
     def from_string(cls, string: str):
         parts = string.split()
-        if 3 < len(parts) < 2:
+        if not (2 <= len(parts) <= 3):
             raise ValueError(
                 f"Unexpected format for 'extra_filetype': expected 'extension comment [lexer]', got {string!r}"
             )

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -128,3 +128,19 @@ def test_update_entity_settings():
 
     assert settings.source is True
     assert settings.version == expected_version
+
+
+def test_extra_filetype():
+    c = ExtraFileType.from_string("c //")
+    assert c == ExtraFileType("c", "//")
+
+    c_with_lexer = ExtraFileType.from_string("c // c_lexer")
+    assert c_with_lexer == ExtraFileType("c", "//", "c_lexer")
+
+
+def test_extra_filetype_error():
+    with pytest.raises(ValueError):
+        ExtraFileType.from_string("c")
+
+    with pytest.raises(ValueError):
+        ExtraFileType.from_string("c // c lexer")


### PR DESCRIPTION
Closes #659 