### PR TITLE
Remove setuptools_scm_git_archive from build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 65",
-    "setuptools_scm[toml] >= 6.2",
-    "setuptools_scm_git_archive",
+    "setuptools_scm[toml] >= 7.0.0",
     "wheel >= 0.29.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
As per [the info in PyPi](https://pypi.org/project/setuptools-scm-git-archive/),
> This plugin is obsolete. `setuptools_scm >= 7.0.0` supports Git archives by itself.

Building and running `pytest` after removing `setuptools_scm_git_archive` returns no errors.

I added FORD to the [AUR](https://aur.archlinux.org/packages/ford) and added this change as a [patch](https://aur.archlinux.org/cgit/aur.git/tree/pyproject.toml.patch?h=ford) because `setuptools-scm-git-archive` is not available on Arch.

Thank you for your time.