### PR TITLE
make creation_date timezone-aware

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -342,7 +342,7 @@ def parse_arguments(
 
     proj_data.normalise_paths(directory)
 
-    proj_data.creation_date = datetime.now().strftime(proj_data.creation_date)
+    proj_data.creation_date = datetime.now().astimezone().strftime(proj_data.creation_date)
 
     # Make sure no src_dir is contained within output_dir
     for srcdir in proj_data.src_dir:


### PR DESCRIPTION
`datetime.now()` returns a naive timestamp in the local TZ. When formatting this timestamp, `%z` and `%Z` directives would therefore always be empty.

This commit calls `.astimezone()` to attach the system TZ to this timestamp. `%z` and `%Z` directives when formatting the timestamp are now respected.