### PR TITLE
Update md_admonition.py to fix issue #665

### DIFF
--- a/ford/md_admonition.py
+++ b/ford/md_admonition.py
@@ -42,9 +42,9 @@ class AdmonitionExtension(Extension):
         """Add Admonition to Markdown instance."""
         md.registerExtension(self)
         md.parser.blockprocessors.deregister("admonition", strict=False)
-        md.preprocessors.register(AdmonitionPreprocessor(md), "admonition-pre", 101)
+        md.preprocessors.register(AdmonitionPreprocessor(md), "admonition-pre", 100)
         md.parser.blockprocessors.register(
-            FordAdmonitionProcessor(md.parser), "admonition", 101
+            FordAdmonitionProcessor(md.parser), "admonition", 100
         )
 
 

--- a/ford/md_admonition.py
+++ b/ford/md_admonition.py
@@ -42,9 +42,9 @@ class AdmonitionExtension(Extension):
         """Add Admonition to Markdown instance."""
         md.registerExtension(self)
         md.parser.blockprocessors.deregister("admonition", strict=False)
-        md.preprocessors.register(AdmonitionPreprocessor(md), "admonition-pre", 105)
+        md.preprocessors.register(AdmonitionPreprocessor(md), "admonition-pre", 101)
         md.parser.blockprocessors.register(
-            FordAdmonitionProcessor(md.parser), "admonition", 105
+            FordAdmonitionProcessor(md.parser), "admonition", 101
         )
 
 


### PR DESCRIPTION
Drops the priority of the admonition to <= markdown_include to ensure included files get admonition's rendered correctly