### PR TITLE
Update README.md to remove incorrect Tipue Search link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Current features include:
   arguments, derived types, programs, and modules from the source code.
 - the ability to extract documentation from comments in the source code.
 - LaTeX support in documentation using [MathJax](https://www.mathjax.org/).
-- searchable documentation, using [Tipue Search](http://www.tipue.com/search/).
+- searchable documentation, using Tipue Search.
 - author description and social media (including Github!) links.
 - links to download the source code.
 - links to individual files, both in their raw form or in HTML with syntax


### PR DESCRIPTION
Tipue website no longer for Tipue search (which appears deprecated).