### PR TITLE
Don't store sub-groups where not needed in regex and other processing optimisations

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -185,7 +185,6 @@ class FortranBase:
 
     POINTS_TO_RE = re.compile(r"\s*=>\s*", re.IGNORECASE)
     SPLIT_RE = re.compile(r"\s*,\s*", re.IGNORECASE)
-    SRC_CAPTURE_STR = r"^[ \t]*(?:[\w(),*: \t]+?[ \t]+)?{0}(?:[\w(),*: \t]+?)?[ \t]+{1}[ \t\n,(].*?end[ \t]*{0}[ \t]+{1}[ \t]*?(?:!.*?)?$"
 
     pretty_obj = {
         "proc": "procedures",
@@ -442,8 +441,9 @@ class FortranBase:
 
         if self.obj in ["proc", "type", "program"] and self.meta.source:
             obj = getattr(self, "proctype", self.obj).lower()
+            SRC_CAPTURE_STR = fr"^[ \t]*(?:[\w(),*: \t]+?[ \t]+)?{obj}(?:[\w(),*: \t]+?)?[ \t]+{self.name}[ \t\n,(].*?end[ \t]*{obj}[ \t]+{self.name}[ \t]*?(?:!.*?)?$"
             regex = re.compile(
-                self.SRC_CAPTURE_STR.format(obj, self.name),
+                SRC_CAPTURE_STR,
                 re.IGNORECASE | re.DOTALL | re.MULTILINE,
             )
             if match := regex.search(self.source_file.raw_src):

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -441,7 +441,7 @@ class FortranBase:
 
         if self.obj in ["proc", "type", "program"] and self.meta.source:
             obj = getattr(self, "proctype", self.obj).lower()
-            SRC_CAPTURE_STR = fr"^[ \t]*(?:[\w(),*: \t]+?[ \t]+)?{obj}(?:[\w(),*: \t]+?)?[ \t]+{self.name}[ \t\n,(].*?end[ \t]*{obj}[ \t]+{self.name}[ \t]*?(?:!.*?)?$"
+            SRC_CAPTURE_STR = fr"^[ \t]*(?:[\w(),*: \t]+?[ \t]+)?\b{obj}\b(?:[\w(),*: \t]+?)?[ \t]+\b{self.name}\b[ \t\n,(].*?\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*?(?:!.*?)?$"
             regex = re.compile(
                 SRC_CAPTURE_STR,
                 re.IGNORECASE | re.DOTALL | re.MULTILINE,

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -441,10 +441,16 @@ class FortranBase:
 
         if self.obj in ["proc", "type", "program"] and self.meta.source:
             obj = getattr(self, "proctype", self.obj).lower()
-            SRC_CAPTURE_STR = fr"^(?:[\w(),*: \t]*?)?\b{obj}\b(?:[\w(),*: \t]+?)?[ \t]+\b{self.name}\b[ \t\n,(].*?^[ \t]*\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*?(?:!.*?)?$"
             regex = re.compile(
-                SRC_CAPTURE_STR,
-                re.IGNORECASE | re.DOTALL | re.MULTILINE,
+                fr"""
+                ^(?:[\w(),*: \t]*?)?         # Attributes, function type
+                \b{obj}\b                    # Subroutine/function
+                (?:[\w(),*: \t]+?)?[ \t]+    # Interstitial nonsense
+                \b{self.name}\b[ \t\n,(].*?  # Entity name
+                ^[ \t]*\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*? # End statement
+                (?:!.*?)?$
+                """,
+                re.IGNORECASE | re.DOTALL | re.MULTILINE | re.VERBOSE,
             )
             if match := regex.search(self.source_file.raw_src):
                 self.src = highlight(

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -185,7 +185,7 @@ class FortranBase:
 
     POINTS_TO_RE = re.compile(r"\s*=>\s*", re.IGNORECASE)
     SPLIT_RE = re.compile(r"\s*,\s*", re.IGNORECASE)
-    SRC_CAPTURE_STR = r"^[ \t]*([\w(),*: \t]+?[ \t]+)?{0}([\w(),*: \t]+?)?[ \t]+{1}[ \t\n,(].*?end[ \t]*{0}[ \t]+{1}[ \t]*?(!.*?)?$"
+    SRC_CAPTURE_STR = r"^[ \t]*(?:[\w(),*: \t]+?[ \t]+)?{0}(?:[\w(),*: \t]+?)?[ \t]+{1}[ \t\n,(].*?end[ \t]*{0}[ \t]+{1}[ \t]*?(?:!.*?)?$"
 
     pretty_obj = {
         "proc": "procedures",

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -441,7 +441,7 @@ class FortranBase:
 
         if self.obj in ["proc", "type", "program"] and self.meta.source:
             obj = getattr(self, "proctype", self.obj).lower()
-            SRC_CAPTURE_STR = fr"^(?:[\w(),*: \t]*?)?\b{obj}\b(?:[\w(),*: \t]+?)?[ \t]+\b{self.name}\b[ \t\n,(].*?\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*?(?:!.*?)?$"
+            SRC_CAPTURE_STR = fr"^(?:[\w(),*: \t]*?)?\b{obj}\b(?:[\w(),*: \t]+?)?[ \t]+\b{self.name}\b[ \t\n,(].*?^[ \t]*\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*?(?:!.*?)?$"
             regex = re.compile(
                 SRC_CAPTURE_STR,
                 re.IGNORECASE | re.DOTALL | re.MULTILINE,

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -441,7 +441,7 @@ class FortranBase:
 
         if self.obj in ["proc", "type", "program"] and self.meta.source:
             obj = getattr(self, "proctype", self.obj).lower()
-            SRC_CAPTURE_STR = fr"^[ \t]*(?:[\w(),*: \t]+?[ \t]+)?\b{obj}\b(?:[\w(),*: \t]+?)?[ \t]+\b{self.name}\b[ \t\n,(].*?\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*?(?:!.*?)?$"
+            SRC_CAPTURE_STR = fr"^(?:[\w(),*: \t]*?)?\b{obj}\b(?:[\w(),*: \t]+?)?[ \t]+\b{self.name}\b[ \t\n,(].*?\bend[ \t]*{obj}\b[ \t]+\b{self.name}\b[ \t]*?(?:!.*?)?$"
             regex = re.compile(
                 SRC_CAPTURE_STR,
                 re.IGNORECASE | re.DOTALL | re.MULTILINE,


### PR DESCRIPTION
Tweaks SRC_CAPTURE_STR to avoid capturing the logical groups in this regex as we don't use them.  This gives a slight optimisation to the "Processing comments" stage.

There are likely a few other places in sourceform that similar adjustments could be made, but they are less likely to give a noticeable speed up as, at least for the project I'm testing with, the SRC_CAPTURE_STR regex search dominates the processing comments stage.