### PR TITLE
Experimental: Avoid subprocess in preprocessing

### DIFF
--- a/ford/reader.py
+++ b/ford/reader.py
@@ -167,17 +167,21 @@ class FortranReader:
             incdirs = [f"-I{d}" for d in self.inc_dirs]
             print(f"Preprocessing {filename}")
             preprocessor_command = preprocessor + macros + incdirs + [filename]
-            if preprocessor_command[0] == 'pcpp':
+            if preprocessor_command[0] == "pcpp":
                 local_out = StringIO()
                 from pcpp.pcmd import CmdPreprocessor
+
                 with redirect_stdout(local_out):
-                    _ = CmdPreprocessor(preprocessor_command)
+                    CmdPreprocessor(preprocessor_command)
                     self.reader = StringIO(local_out.getvalue())
             else:
-                command = ' '.join(preprocessor_command)
+                command = " ".join(preprocessor_command)
                 try:
                     out = subprocess.run(
-                        preprocessor_command, encoding=encoding, check=True, capture_output=True
+                        preprocessor_command,
+                        encoding=encoding,
+                        check=True,
+                        capture_output=True,
                     )
                     if out.stderr:
                         warn(

--- a/ford/reader.py
+++ b/ford/reader.py
@@ -158,7 +158,6 @@ class FortranReader:
         self.reader: Union[StringIO, TextIOWrapper]
 
         if preprocessor:
-            preprocessor_command = preprocessor.split(' ')
             # Populate the macro definition and include directory path from
             # the input lists.  To define a macro we prepend '-D' and for an
             # include path we prepend '-I'.  It's important that we do not
@@ -167,7 +166,7 @@ class FortranReader:
             macros = ["-D" + mac.strip() for mac in filter(None, macros or [])]
             incdirs = [f"-I{d}" for d in self.inc_dirs]
             print(f"Preprocessing {filename}")
-            preprocessor_command.extend(macros + incdirs + [filename])
+            preprocessor_command = preprocessor + macros + incdirs + [filename]
             if preprocessor_command[0] == 'pcpp':
                 local_out = StringIO()
                 from pcpp.pcmd import CmdPreprocessor

--- a/ford/reader.py
+++ b/ford/reader.py
@@ -157,20 +157,8 @@ class FortranReader:
 
         self.reader: Union[StringIO, TextIOWrapper]
 
-        if preprocessor == 'pcpp -D__GFORTRAN__ --passthru-comments':
-            # Hacky way to detect if the user hasn't changed from the default
-            # We might just want to check if the first word is pcpp?
-            macros = ["-D" + mac.strip() for mac in filter(None, macros or [])]
-            incdirs = [f"-I{d}" for d in self.inc_dirs]
-            print(f"Preprocessing {filename}")
-            opts = preprocessor.split(' ')
-            opts.extend(macros + incdirs + [filename])
-            local_out = StringIO()
-            from pcpp.pcmd import CmdPreprocessor
-            with redirect_stdout(local_out):
-                _ = CmdPreprocessor(opts)
-            self.reader = StringIO(local_out.getvalue())
-        elif preprocessor:
+        if preprocessor:
+            preprocessor_command = preprocessor.split(' ')
             # Populate the macro definition and include directory path from
             # the input lists.  To define a macro we prepend '-D' and for an
             # include path we prepend '-I'.  It's important that we do not
@@ -178,24 +166,31 @@ class FortranReader:
             # what is desired; use filter to remove these.
             macros = ["-D" + mac.strip() for mac in filter(None, macros or [])]
             incdirs = [f"-I{d}" for d in self.inc_dirs]
-            preprocessor = preprocessor + macros + incdirs + [filename]
-            command = " ".join(preprocessor)
             print(f"Preprocessing {filename}")
-            try:
-                out = subprocess.run(
-                    preprocessor, encoding=encoding, check=True, capture_output=True
-                )
-                if out.stderr:
-                    warn(
-                        f"Warning when preprocessing {filename}:\n{command}\n{out.stderr}"
+            preprocessor_command.extend(macros + incdirs + [filename])
+            if preprocessor_command[0] == 'pcpp':
+                local_out = StringIO()
+                from pcpp.pcmd import CmdPreprocessor
+                with redirect_stdout(local_out):
+                    _ = CmdPreprocessor(preprocessor_command)
+                    self.reader = StringIO(local_out.getvalue())
+            else:
+                command = ' '.join(preprocessor_command)
+                try:
+                    out = subprocess.run(
+                        preprocessor_command, encoding=encoding, check=True, capture_output=True
                     )
-                self.reader = StringIO(out.stdout)
-            except subprocess.CalledProcessError as err:
-                warn(
-                    f"error when preprocessing {filename}:\n{command}\n{err.stderr}\n"
-                    "Reverting to unpreprocessed file"
-                )
-                self.reader = open(filename, "r", encoding=encoding)
+                    if out.stderr:
+                        warn(
+                            f"Warning when preprocessing {filename}:\n{command}\n{out.stderr}"
+                        )
+                    self.reader = StringIO(out.stdout)
+                except subprocess.CalledProcessError as err:
+                    warn(
+                        f"error when preprocessing {filename}:\n{command}\n{err.stderr}\n"
+                        "Reverting to unpreprocessed file"
+                    )
+                    self.reader = open(filename, "r", encoding=encoding)
         else:
             self.reader = open(filename, "r", encoding=encoding)
 


### PR DESCRIPTION
When using `pcpp` we can avoid using subprocess to call the `pcpp` executable and simply construct a `CmdPreprocessor` object directly. This can save a little potential overhead of starting new processes.