### PR TITLE
Experimental/allow user specified html template directory

### DIFF
--- a/ford/output.py
+++ b/ford/output.py
@@ -45,7 +45,6 @@ from ford.settings import ProjectSettings, EntitySettings
 
 loc = pathlib.Path(__file__).parent
 env = jinja2.Environment(
-    loader=jinja2.FileSystemLoader(loc / "templates"),
     trim_blocks=True,
     lstrip_blocks=True,
 )
@@ -120,6 +119,10 @@ class Documentation:
         # Also, in future for other template, we may not need to
         # pass the data obj.
         env.globals["projectData"] = asdict(settings)
+        env.loader=jinja2.FileSystemLoader(
+            settings.html_template_dir + [loc / "templates"]
+        )
+
         self.project = project
         self.settings = settings
         # Jinja2's `if` statement counts `None` as truthy, so to avoid

--- a/ford/settings.py
+++ b/ford/settings.py
@@ -161,6 +161,7 @@ class ProjectSettings:
     graph_maxdepth: int = 10000
     graph_maxnodes: int = 1000000000
     hide_undoc: bool = False
+    html_template_dir: List[Path] = field(default_factory=list)
     incl_src: bool = True
     include: List[Path] = field(default_factory=list)
     license: str = ""


### PR DESCRIPTION
Adds `html_template_dir` setting with which user can specify a list of paths which jinja2 should search for html templates before looking in the default templates directory shipped with ford.

Paths can be absolute or relative to the config file.

No options for changing template file names or broader structure so perhaps only really useful for tweaking current layout, but with this I could remove the jumbotron, for example.