### PR TITLE
Add backslash as escape for alias

### DIFF
--- a/docs/user_guide/writing_documentation.rst
+++ b/docs/user_guide/writing_documentation.rst
@@ -243,7 +243,7 @@ There are three predefined macros:
 - ``|media|``: the (absolute) path to the `media directory <option-media_dir>`
 - ``|page|``: the `static page directory <option-page_dir>`
 
-You can defined additional custom aliases with the `alias
+You can define additional custom aliases with the `alias
 <option-alias>` option.
 
 .. note::
@@ -260,6 +260,11 @@ You can defined additional custom aliases with the `alias
        | [link](|page|/subpage2.html) | |note_no_space_in_alias| |
 
    This avoids clashes between the syntax for the two features.
+
+
+.. note::
+   An alias can be escaped with a prepended baskslash, such that `|foo|` will
+   be replaced with its alias, while `\|foo|` will be rendered as `|foo|`.
 
 
 .. _writing-links:

--- a/test/test_markdown.py
+++ b/test/test_markdown.py
@@ -5,8 +5,24 @@ from textwrap import dedent
 
 def test_sub_alias():
     result = MetaMarkdown(aliases={"a": "b"}).convert("|a|")
-
     assert result == "<p>b</p>"
+
+    result = MetaMarkdown(aliases={"a": "b"}).convert("|undefined|")
+    assert result == "<p>|undefined|</p>"
+
+
+def test_sub_alias_escape():
+    def_alias={"a":"b"}
+
+    result = MetaMarkdown(aliases=def_alias).convert("\|a|")
+    assert result == "<p>|a|</p>"
+
+    result = MetaMarkdown(aliases=def_alias).convert("*|a|")
+    assert result == "<p>*b</p>"
+
+    result = MetaMarkdown(aliases=def_alias).convert("\|undefined|")
+    assert result == "<p>|undefined|</p>"
+
 
 
 def test_sub_alias_with_equals():


### PR DESCRIPTION
Pull request for issue #678 

Add backslash as escape character for `alias`, such that `\|foo|` is not replaced, while `|foo|` is.