### PR TITLE
Make error message when failing to parse ford link a bit friendlier

### DIFF
--- a/ford/_markdown.py
+++ b/ford/_markdown.py
@@ -219,6 +219,8 @@ class FordLinkProcessor(InlineProcessor):
         name = m["name"]
 
         def find_child(context):
+            # This is allowed to fail because we might be looking for
+            # "entity" in the wrong context
             with suppress(ValueError):
                 return context.find_child(name, m["entity"])
 
@@ -229,7 +231,12 @@ class FordLinkProcessor(InlineProcessor):
                 item = find_child(parent)
 
             if m["child_name"] and item is not None:
-                item = item.find_child(m["child_name"], m["child_entity"])
+                try:
+                    # This isn't allowed to fail because the user has
+                    # given us all the information required
+                    item = item.find_child(m["child_name"], m["child_entity"])
+                except ValueError as e:
+                    raise ValueError(f"Error when parsing link '{m.group()}': {e}")
 
         if item is None:
             item = self.project.find(**m.groupdict())

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -422,9 +422,14 @@ class FortranBase:
 
         # Remove any common leading whitespace from the docstring
         # so that the markdown conversion is a bit more robust
-        self.doc = md.reset().convert(
-            textwrap.dedent("\n".join(self.doc_list)), context=self
-        )
+        try:
+            self.doc = md.reset().convert(
+                textwrap.dedent("\n".join(self.doc_list)), context=self
+            )
+        except (RuntimeError, ValueError) as e:
+            raise ValueError(
+                f"Error when rendering docstring for {self.obj} '{self.name}' in '{self.filename}':\n    {e}"
+            )
 
         if self.meta.summary is not None:
             self.meta.summary = md.convert("\n".join(self.meta.summary), context=self)


### PR DESCRIPTION
Closes #691

Example of new error message:

```
ValueError: Error when rendering docstring for type 'foo' in 'ford_test_program.f90':
    Error when parsing link '[[foo(type):do_foo_stuff(subroutine)]]': 'type' cannot have child 'subroutine'
```

@runburg Thoughts?