### PR TITLE
Raise error if fixed-form extension also appears in `extensions`

### DIFF
--- a/ford/settings.py
+++ b/ford/settings.py
@@ -336,7 +336,9 @@ def load_markdown_settings(
             settings[option] = "\n".join(include_preprocessor.run(value.splitlines()))
 
     try:
-        return ProjectSettings.from_markdown_metadata(settings), "\n".join(project_lines)
+        return ProjectSettings.from_markdown_metadata(settings), "\n".join(
+            project_lines
+        )
     except ValueError as e:
         raise ValueError(f"Error parsing settings from '{filename}': {e}")
 

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -144,3 +144,21 @@ def test_extra_filetype_error():
 
     with pytest.raises(ValueError):
         ExtraFileType.from_string("c // c lexer")
+
+
+def test_duplicated_fixed_extension():
+    text = dedent(
+        '''\
+    project = "some project"
+    src_dir = "source"
+    summary = """
+    first
+    second"""
+    preprocess = true
+    fpp_extensions = ["fpp", "F90"]
+    fixed_extensions = ["f"]
+    extensions = ["f90", "f"]
+        '''
+    )
+    with pytest.raises(ValueError):
+        ProjectSettings(**tomllib.loads(text))


### PR DESCRIPTION
Closes #686

Example error message:

```
ValueError: Error parsing settings from 'example-project-file.md': Fixed-form extension 'f' also appears in free-form extension list (`extensions = ['f']`)
```

In the interests of getting something in, this just raises an
exception, rather than trying to be clever and automatically remove it
from the fixed-form list. Hopefully the error message is clear enough.

@banana-bred Thoughts?