### PR TITLE
Fix `[[ford]]` links to external entities

### DIFF
--- a/ford/_markdown.py
+++ b/ford/_markdown.py
@@ -264,9 +264,13 @@ class FordLinkProcessor(InlineProcessor):
             # This is really to keep mypy happy
             raise RuntimeError(f"Found item {name} but no url")
 
-        # Make sure links are relative to base url
-        full_url = self.md.base_url / item_url
-        rel_url = relpath(full_url, self.md.current_path)
+        # Make sure links are relative to base url, unless they are
+        # already absolute (because they're external)
+        if item_url.startswith("http"):
+            rel_url = item_url
+        else:
+            full_url = self.md.base_url / item_url
+            rel_url = relpath(full_url, self.md.current_path)
         link.attrib["href"] = str(rel_url)
         link.text = item.name
         return link

--- a/test/test_projects/test_external_project.py
+++ b/test/test_projects/test_external_project.py
@@ -179,3 +179,16 @@ def test_procedure_module_use_links_(external_project):
     local_url = urlparse(links["external_module"])
     local_path = proc_dir / local_url.path
     assert local_path.is_file()
+
+
+def test_external_ford_link(external_project):
+    """Test #696 -- malformed [[ford]] links to external entities"""
+
+    top_level_project, _ = external_project
+
+    prog_dir = top_level_project / "doc/program"
+    with open(prog_dir / "top_level.html") as f:
+        prog_html = BeautifulSoup(f.read(), features="html.parser")
+
+    link = prog_html.find("a", string="remote_sub")
+    assert link["href"] == "https://example.com/proc/remote_sub.html"

--- a/test_data/external_project/top_level_project/src/top_level.f90
+++ b/test_data/external_project/top_level_project/src/top_level.f90
@@ -43,7 +43,8 @@ end module myAbort
 
 program top_level
   !! This program uses a module from some external source, whose
-  !! documentation will be linked to from this documentation
+  !! documentation will be linked to from this documentation.
+  !! This uses [[remote_sub]].
   use external_module
   use remote_module
   use myAbort


### PR DESCRIPTION
Fixes #696

We've been testing that Ford's automatic links all work correctly with external projects, and hadn't actually checked that users' links work.