### PR TITLE
Fix incorrect handling for the `summary` key in documentation metadata

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -432,7 +432,7 @@ class FortranBase:
             )
 
         if self.meta.summary is not None:
-            self.meta.summary = md.convert("\n".join(self.meta.summary), context=self)
+            self.meta.summary = md.convert(" ".join(self.meta.summary.split()), context=self)
         elif paragraph := PARA_CAPTURE_RE.search(self.doc):
             # If there is no stand-alone webpage for this item, e.g.
             # an internal routine, make the whole doc blob appear,

--- a/test/test_sourceform.py
+++ b/test/test_sourceform.py
@@ -2268,3 +2268,24 @@ def test_no_space_after_character_type(parse_fortran_file):
     source = parse_fortran_file(data)
     function = source.functions[0]
     assert function.name.lower() == "firstword"
+
+
+def test_summary_handling_bug703(parse_fortran_file):
+    """Check that `summary` works, PR #703"""
+    data = """\
+    !> summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    !>          Fusce ultrices tortor et felis tempus vehicula.
+    !>          Nulla gravida, magna ut pharetra.
+    !>
+    !> Full description
+    module test
+    end module myModule
+    """
+
+    fortran_file = parse_fortran_file(data)
+    md = MetaMarkdown()
+
+    module = fortran_file.modules[0]
+    module.markdown(md)
+
+    assert "Lorem ipsum" in module.meta.summary


### PR DESCRIPTION
When the `summary` key is used in documentation metadata, FORD generates garbled contents for the summary field of the documented program unit.

For example, with the documentation metadata below,

```
!> summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
!>          Fusce ultrices tortor et felis tempus vehicula.
!>          Nulla gravida, magna ut pharetra.
```

FORD generates the following HTML source code, which is obviously incorrect:

```
<p>L\no\nr\ne\nm</p>\n<p>i\np\ns\nu\nm</p>\n<p>d\no\nl\no\nr</p>\n<p>s\ni\nt</p>\n<p>a\nm\ne\nt\n,</p>\n<p>c\no\nn\ns\ne\nc\nt\ne\nt\nu\nr</p>\n<p>a\nd\ni\np\ni\ns\nc\ni\nn\ng</p>\n<p>e\nl\ni\nt\n.</p>\n<p>F\nu\ns\nc\ne</p>\n<p>u\nl\nt\nr\ni\nc\ne\ns</p>\n<p>t\no\nr\nt\no\nr</p>\n<p>e\nt</p>\n<p>f\ne\nl\ni\ns</p>\n<p>t\ne\nm\np\nu\ns</p>\n<p>v\ne\nh\ni\nc\nu\nl\na\n.</p>\n<p>N\nu\nl\nl\na</p>\n<p>g\nr\na\nv\ni\nd\na\n,</p>\n<p>m\na\ng\nn\na</p>\n<p>u\nt</p>\n<p>p\nh\na\nr\ne\nt\nr\na\n.</p>
```

The expected output should be:

```
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce ultrices tortor et felis tempus vehicula. Nulla gravida, magna ut pharetra.</p>
```

This PR ensures that the summary field correctly contains a single paragraph of text.

-----

To reproduce this issue, consider the minimal reproducible example below.

1. `test_summary_key.md`

```
---
project: Test Summary Key
summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         Fusce ultrices tortor et felis tempus vehicula.
         Nulla gravida, magna ut pharetra.
author: Tester
---

Test the `summary` key in project and documentation metadata.
```

2. `src/test_summary_key.f90`

```
!> summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
!>          Fusce ultrices tortor et felis tempus vehicula.
!>          Nulla gravida, magna ut pharetra.
!>
!> Descriptions for module `m`.
module m
    implicit none
contains
    !> summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
    !>          Fusce ultrices tortor et felis tempus vehicula.
    !>          Nulla gravida, magna ut pharetra.
    !>
    !> Descriptions for function `f`.
    function f(a, b)
        integer, intent(in) :: a, b
        integer :: f

        f = 0
    end function f

    !> summary: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
    !>          Fusce ultrices tortor et felis tempus vehicula.
    !>          Nulla gravida, magna ut pharetra.
    !>
    !> Descriptions for subroutine `s`.
    subroutine s(a, b)
        integer, intent(in) :: a, b
    end subroutine s
end module m
```

3. Run FORD to generate the documentation. Inspect the "Modules" and "Procedures" pages.
