### PR TITLE
Add GNU License Family

### DIFF
--- a/docs/user_guide/project_file_options.rst
+++ b/docs/user_guide/project_file_options.rst
@@ -209,6 +209,7 @@ license
 
 The licenses under which the software is released. Options are:
 
+- **agpl**: `GNU Affero General Public License <http://www.gnu.org/licenses/agpl>`_
 - **bsd**: `FreeBSD Documentation License <http://www.freebsd.org/copyright/freebsd-doc-license.html>`_
 - **by**: `Creative Commons attribution <http://creativecommons.org/licenses/by/4.0/>`_
 - **by-nc**: `Creative Commons attribution, non-commercial <http://creativecommons.org/licenses/by-nc/4.0/>`_
@@ -217,7 +218,9 @@ The licenses under which the software is released. Options are:
 - **by-nd**: `Creative Commons attribution, no derivatives <http://creativecommons.org/licenses/by-nd/4.0/>`_
 - **by-sa**: `Creative Commons attribution, share-alike <http://creativecommons.org/licenses/by-sa/4.0/>`_
 - **gfdl**: `GNU Free Documentation License <http://www.gnu.org/licenses/old-licenses/fdl-1.2.en.html>`_
+- **gpl**: `GNU General Public License <http://www.gnu.org/licenses/gpl>`_
 - **isc**: `ISC (Internet Systems Consortium) License <https://opensource.org/licenses/ISC>`_
+- **lgpl**: `GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl>`_
 - **mit**: `MIT <https://opensource.org/licenses/MIT>`_
 - **opl**: `Open Publication License <http://opencontent.org/openpub/>`_
 - **pdl**: `Public Documentation License <http://www.openoffice.org/licenses/PDL.html>`_

--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -115,6 +115,18 @@ LICENSES = {
         '<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">'
         '<img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>'
     ),
+    "gpl": (
+        '<a rel="license" href="http://www.gnu.org/licenses/gpl">'
+        '<img alt="GNU General Public License" style="border-width:0" src="https://www.gnu.org/graphics/gplv3-88x31.png" /></a>'
+    ),
+    "lgpl": (
+        '<a rel="license" href="http://www.gnu.org/licenses/lgpl">'
+        '<img alt="GNU Lesser General Public License" style="border-width:0" src="https://www.gnu.org/graphics/lgplv3-88x31.png" /></a>'
+    ),
+    "agpl": (
+        '<a rel="license" href="http://www.gnu.org/licenses/agpl">'
+        '<img alt="GNU Affero General Public License" style="border-width:0" src="https://www.gnu.org/graphics/agplv3-88x31.png" /></a>'
+    ),
     "gfdl": '<a rel="license" href="http://www.gnu.org/licenses/old-licenses/fdl-1.2.en.html">GNU Free Documentation License</a>',
     "opl": '<a rel="license" href="http://opencontent.org/openpub/">Open Publication License</a>',
     "pdl": '<a rel="license" href="http://www.openoffice.org/licenses/PDL.html">Public Documentation License</a>',


### PR DESCRIPTION
The [project file options](https://forddocs.readthedocs.io/en/stable/user_guide/project_file_options.html) allow selecting a project license. This change adds support for the GNU License Family, including:

- GNU General Public License (GPL)
- GNU Lesser General Public License (LGPL)
- GNU Affero General Public License (AGPL)

For more details, see the documentation:
https://forddocs.readthedocs.io/en/stable/user_guide/project_file_options.html#license

Let me know if any refinements are needed!